### PR TITLE
fix(runtime): support strict Codex output schemas

### DIFF
--- a/src/runtimes/types.ts
+++ b/src/runtimes/types.ts
@@ -77,13 +77,14 @@ export function validateRuntimeOutput(value: unknown): RuntimeOutput | null {
   const reply = output.reply.trim();
   if (reply.length === 0 || reply.length > MAX_RUNTIME_TEXT_CHARACTERS) return null;
   let summary: string | undefined;
-  if (output.summary !== undefined) {
+  if (output.summary !== undefined && output.summary !== null) {
     if (typeof output.summary !== "string") return null;
-    summary = output.summary.trim();
-    if (summary.length === 0 || summary.length > MAX_RUNTIME_TEXT_CHARACTERS) return null;
+    const normalizedSummary = output.summary.trim();
+    if (normalizedSummary.length > MAX_RUNTIME_TEXT_CHARACTERS) return null;
+    if (normalizedSummary.length > 0) summary = normalizedSummary;
   }
   let workspaceCandidates: string[] | undefined;
-  if (output.workspaceCandidates !== undefined) {
+  if (output.workspaceCandidates !== undefined && output.workspaceCandidates !== null) {
     if (
       !Array.isArray(output.workspaceCandidates) ||
       output.workspaceCandidates.length === 0 ||
@@ -108,14 +109,18 @@ export const RUNTIME_OUTPUT_SCHEMA = {
   additionalProperties: false,
   properties: {
     reply: { maxLength: MAX_RUNTIME_TEXT_CHARACTERS, minLength: 1, type: "string" },
-    summary: { maxLength: MAX_RUNTIME_TEXT_CHARACTERS, minLength: 1, type: "string" },
+    summary: {
+      maxLength: MAX_RUNTIME_TEXT_CHARACTERS,
+      minLength: 1,
+      type: ["string", "null"],
+    },
     workspaceCandidates: {
       items: { maxLength: 4_096, minLength: 1, type: "string" },
       maxItems: MAX_WORKSPACE_CANDIDATES,
       minItems: 1,
-      type: "array",
+      type: ["array", "null"],
     },
   },
-  required: ["reply"],
+  required: ["reply", "summary", "workspaceCandidates"],
   type: "object",
 } as const;

--- a/test/unit/runtime-output.test.ts
+++ b/test/unit/runtime-output.test.ts
@@ -1,5 +1,23 @@
 import { expect, test } from "bun:test";
-import { validateRuntimeOutput } from "../../src/runtimes/types";
+import { RUNTIME_OUTPUT_SCHEMA, validateRuntimeOutput } from "../../src/runtimes/types";
+
+test("uses a strict Codex-compatible schema while preserving optional output fields", () => {
+  expect(RUNTIME_OUTPUT_SCHEMA.required).toEqual([
+    "reply",
+    "summary",
+    "workspaceCandidates",
+  ]);
+  expect(validateRuntimeOutput({
+    reply: "Done.",
+    summary: null,
+    workspaceCandidates: null,
+  })).toEqual({ reply: "Done." });
+  expect(validateRuntimeOutput({
+    reply: "Done.",
+    summary: "   ",
+    workspaceCandidates: null,
+  })).toEqual({ reply: "Done." });
+});
 
 test("accepts bounded workspace candidates in structured runtime output", () => {
   expect(


### PR DESCRIPTION
Codex fallback setup now completes instead of failing its effective-permissions probe with `invalid_json_schema`. The shared schema marks optional fields as required-but-nullable for strict structured output, then normalizes `null` and blank summaries back to the existing optional domain shape.

Validated with all 117 tests, the compiled build, release validation, and live unrestricted file-tool probes through both Codex and Claude.