### PR TITLE
fix(imessage): handle service-less tagged events

### DIFF
--- a/src/imessage/transport.ts
+++ b/src/imessage/transport.ts
@@ -27,8 +27,22 @@ export class ImsgTransport {
   }
 
   async ownerParticipated(chatId: number): Promise<boolean> {
+    return (await this.#chatEligibility(chatId)).ownerParticipated;
+  }
+
+  async #chatEligibility(chatId: number): Promise<{
+    ownerParticipated: boolean;
+    service: string | null;
+  }> {
     const result = object(await this.rpc.call("messages.stats", { chat_id: chatId }));
-    return typeof result.sent_messages === "number" && result.sent_messages > 0;
+    const chat = (Array.isArray(result.chats) ? result.chats : [])
+      .map(object)
+      .find((candidate) => candidate.chat_id === chatId);
+    return {
+      ownerParticipated:
+        typeof result.sent_messages === "number" && result.sent_messages > 0,
+      service: chat !== undefined && typeof chat.service === "string" ? chat.service : null,
+    };
   }
 
   async activationFor(raw: unknown, tag: string): Promise<ActivatedRequest | null> {
@@ -47,7 +61,19 @@ export class ImsgTransport {
     ) {
       return null;
     }
-    const candidate = activatedRequest(message, tag, true);
+    let candidate = activatedRequest(message, tag, true);
+    if (candidate === null && message.service === null) {
+      const potentialCandidate = activatedRequest({ ...message, service: "iMessage" }, tag, true);
+      if (potentialCandidate === null) return null;
+      const eligibility = await this.#chatEligibility(potentialCandidate.chatId);
+      if (
+        !eligibility.ownerParticipated ||
+        eligibility.service?.toLowerCase() !== "imessage"
+      ) {
+        return null;
+      }
+      return potentialCandidate;
+    }
     if (candidate === null) return null;
     return (await this.ownerParticipated(candidate.chatId)) ? candidate : null;
   }

--- a/src/macos/launch-agent.ts
+++ b/src/macos/launch-agent.ts
@@ -10,6 +10,9 @@ export interface ProcessResult {
 
 export type LaunchctlRunner = (args: readonly string[]) => Promise<ProcessResult>;
 
+const BOOTOUT_POLL_INTERVAL_MS = 100;
+const BOOTOUT_POLL_ATTEMPTS = 50;
+
 export type LaunchAgentState = "running" | "loaded" | "stopped";
 
 export function parseLaunchAgentState(result: ProcessResult): LaunchAgentState {
@@ -77,14 +80,26 @@ export async function installLaunchAgent(input: {
   plistPath: string;
   runner?: LaunchctlRunner;
   uid?: number;
+  wait?: (milliseconds: number) => Promise<void>;
 }): Promise<void> {
   const runner = input.runner ?? runLaunchctl;
+  const wait = input.wait ?? Bun.sleep;
   const uid = input.uid ?? process.getuid?.();
   if (uid === undefined) throw new Error("Unable to determine the current user ID");
   const service = `gui/${uid}/${LAUNCH_AGENT_LABEL}`;
 
   await atomicWritePrivate(input.plistPath, input.plist);
   await runner(["bootout", service]);
+  for (let attempt = 0; attempt < BOOTOUT_POLL_ATTEMPTS; attempt += 1) {
+    const current = await runner(["print", service]);
+    if (current.exitCode !== 0) break;
+    if (attempt === BOOTOUT_POLL_ATTEMPTS - 1) {
+      throw new Error(
+        `launchctl bootout timed out while replacing ${LAUNCH_AGENT_LABEL}; run setup again`,
+      );
+    }
+    await wait(BOOTOUT_POLL_INTERVAL_MS);
+  }
   const bootstrap = await runner(["bootstrap", `gui/${uid}`, input.plistPath]);
   if (bootstrap.exitCode !== 0) {
     await unlink(input.plistPath).catch(() => undefined);

--- a/test/unit/imsg-transport.test.ts
+++ b/test/unit/imsg-transport.test.ts
@@ -9,10 +9,17 @@ class FakeRpc implements ImsgRpc {
   calls: Array<{ method: string; params: Record<string, unknown> }> = [];
   handlers = new Map<string, Set<(params: unknown) => void | Promise<void>>>();
   result: unknown = { guid: "OUT-1", ok: true };
+  stats: unknown = {
+    chats: [{ chat_id: 42, service: "iMessage" }],
+    sent_messages: 1,
+  };
 
   async call(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
     this.calls.push({ method, params });
-    if (method === "messages.stats") return { sent_messages: 1 };
+    if (method === "messages.stats") {
+      if (this.stats instanceof Error) throw this.stats;
+      return this.stats;
+    }
     if (method === "watch.subscribe") return { subscription: 7 };
     if (method === "watch.unsubscribe") return { ok: true };
     if (this.result instanceof Error) throw this.result;
@@ -30,6 +37,50 @@ class FakeRpc implements ImsgRpc {
     for (const handler of this.handlers.get(method) ?? []) await handler(params);
   }
 }
+
+describe("activation routing", () => {
+  const messageWithoutService = {
+    chat_id: 42,
+    guid: "IN-1",
+    id: 11,
+    text: "@helper continue",
+  };
+
+  test("uses the matching chat service when an imsg message omits its service", async () => {
+    const rpc = new FakeRpc();
+
+    expect(await new ImsgTransport(rpc).activationFor(messageWithoutService, "@helper")).toMatchObject({
+      chatId: 42,
+      providerGuid: "IN-1",
+      request: "continue",
+    });
+    expect(rpc.calls.map((call) => call.method)).toEqual(["messages.stats"]);
+  });
+
+  test("still rejects owner-absent, missing, or non-iMessage chat routing", async () => {
+    for (const stats of [
+      { chats: [{ chat_id: 42, service: "iMessage" }], sent_messages: 0 },
+      { chats: [{ chat_id: 42, service: "SMS" }], sent_messages: 1 },
+      { chats: [{ chat_id: 42 }], sent_messages: 1 },
+      { chats: [{ chat_id: 99, service: "iMessage" }], sent_messages: 1 },
+    ]) {
+      const rpc = new FakeRpc();
+      rpc.stats = stats;
+
+      expect(await new ImsgTransport(rpc).activationFor(messageWithoutService, "@helper")).toBeNull();
+      expect(rpc.calls.map((call) => call.method)).toEqual(["messages.stats"]);
+    }
+  });
+
+  test("surfaces routing lookup failures instead of treating them as ineligible", async () => {
+    const rpc = new FakeRpc();
+    rpc.stats = new Error("stats unavailable");
+
+    await expect(
+      new ImsgTransport(rpc).activationFor(messageWithoutService, "@helper"),
+    ).rejects.toThrow("stats unavailable");
+  });
+});
 
 describe("text delivery", () => {
   test("targets the originating chat and confirms only a GUID-bearing result", async () => {
@@ -115,7 +166,6 @@ test("watch filters activations and surfaces a resumable overflow cursor", async
       chat_id: 42,
       guid: "IN-1",
       id: 11,
-      service: "iMessage",
       text: "@helper continue",
     },
     subscription: 7,

--- a/test/unit/launch-agent.test.ts
+++ b/test/unit/launch-agent.test.ts
@@ -50,7 +50,11 @@ test("installs and bootstraps one LaunchAgent", async () => {
   const calls: string[][] = [];
   const runner: LaunchctlRunner = async (args) => {
     calls.push([...args]);
-    return { exitCode: args[0] === "bootout" ? 3 : 0, stderr: "", stdout: "" };
+    return {
+      exitCode: args[0] === "bootout" || args[0] === "print" ? 3 : 0,
+      stderr: "",
+      stdout: "",
+    };
   };
 
   await installLaunchAgent({
@@ -63,9 +67,85 @@ test("installs and bootstraps one LaunchAgent", async () => {
   expect(await readFile(plistPath, "utf8")).toContain("<plist>");
   expect(calls).toEqual([
     ["bootout", "gui/501/dev.s4imsg.agent"],
+    ["print", "gui/501/dev.s4imsg.agent"],
     ["bootstrap", "gui/501", plistPath],
     ["kickstart", "-k", "gui/501/dev.s4imsg.agent"],
   ]);
+});
+
+test("waits for a LaunchAgent to disappear even when bootout reports in progress", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "s4imsg-agent-"));
+  temporaryDirectories.push(directory);
+  const plistPath = join(directory, "dev.s4imsg.agent.plist");
+  const calls: string[][] = [];
+  const waits: number[] = [];
+  let printCalls = 0;
+  const runner: LaunchctlRunner = async (args) => {
+    calls.push([...args]);
+    if (args[0] === "bootout") {
+      return { exitCode: 36, stderr: "Operation now in progress", stdout: "" };
+    }
+    if (args[0] === "print") {
+      printCalls += 1;
+      return {
+        exitCode: printCalls < 3 ? 0 : 3,
+        stderr: printCalls < 3 ? "" : "Could not find service",
+        stdout: printCalls < 3 ? "state = running\npid = 123\n" : "",
+      };
+    }
+    return { exitCode: 0, stderr: "", stdout: "" };
+  };
+
+  await installLaunchAgent({
+    plist: "<?xml version=\"1.0\"?><plist></plist>\n",
+    plistPath,
+    runner,
+    uid: 501,
+    wait: async (milliseconds) => {
+      waits.push(milliseconds);
+    },
+  });
+
+  expect(calls).toEqual([
+    ["bootout", "gui/501/dev.s4imsg.agent"],
+    ["print", "gui/501/dev.s4imsg.agent"],
+    ["print", "gui/501/dev.s4imsg.agent"],
+    ["print", "gui/501/dev.s4imsg.agent"],
+    ["bootstrap", "gui/501", plistPath],
+    ["kickstart", "-k", "gui/501/dev.s4imsg.agent"],
+  ]);
+  expect(waits).toEqual([100, 100]);
+});
+
+test("keeps the replacement plist and does not bootstrap when bootout times out", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "s4imsg-agent-"));
+  temporaryDirectories.push(directory);
+  const plistPath = join(directory, "dev.s4imsg.agent.plist");
+  const calls: string[][] = [];
+  const waits: number[] = [];
+  const runner: LaunchctlRunner = async (args) => {
+    calls.push([...args]);
+    return { exitCode: 0, stderr: "", stdout: "state = running\npid = 123\n" };
+  };
+
+  await expect(
+    installLaunchAgent({
+      plist: "<?xml version=\"1.0\"?><plist></plist>\n",
+      plistPath,
+      runner,
+      uid: 501,
+      wait: async (milliseconds) => {
+        waits.push(milliseconds);
+      },
+    }),
+  ).rejects.toThrow("run setup again");
+
+  expect(calls.filter(([command]) => command === "print")).toHaveLength(50);
+  expect(calls.some(([command]) => command === "bootstrap" || command === "kickstart")).toBe(
+    false,
+  );
+  expect(waits).toHaveLength(49);
+  expect(await readFile(plistPath, "utf8")).toContain("<plist>");
 });
 
 test("removes a partial plist when launchd bootstrap fails", async () => {
@@ -77,11 +157,16 @@ test("removes a partial plist when launchd bootstrap fails", async () => {
     installLaunchAgent({
       plist: "<?xml version=\"1.0\"?><plist></plist>\n",
       plistPath,
-      runner: async (args) => ({
-        exitCode: args[0] === "bootstrap" ? 1 : 0,
-        stderr: "synthetic bootstrap failure",
-        stdout: "",
-      }),
+      runner: async (args) => {
+        if (args[0] === "bootout" || args[0] === "print") {
+          return { exitCode: 3, stderr: "Could not find service", stdout: "" };
+        }
+        return {
+          exitCode: args[0] === "bootstrap" ? 1 : 0,
+          stderr: "synthetic bootstrap failure",
+          stdout: "",
+        };
+      },
       uid: 501,
     }),
   ).rejects.toThrow("synthetic bootstrap failure");


### PR DESCRIPTION
## Summary

Tagged commands now work with `imsg 0.14.1` even when live and catch-up message events omit service metadata. s4imsg verifies the exact chat's iMessage service and owner participation through `messages.stats` before activation. Missing or mismatched routing metadata still fails closed, while RPC failures remain retryable instead of silently discarding the tag.

## Validation

- `bun run typecheck`
- `bun test` (120 tests passed)
- `bun run release:validate`
- Confirmed the installed `imsg 0.14.1` RPC exposes `chat_id` and `service` in the scoped `messages.stats` result
