### PR TITLE
chore: make s4imsg ready for public use

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Report a reproducible s4imsg problem without private conversation data
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve s4imsg. Never paste real message text, participant handles, chat identifiers, attachment paths, credentials, or provider output. Report security issues through a private advisory instead.
+  - type: input
+    id: version
+    attributes:
+      label: s4imsg version or commit
+      placeholder: 0.1.0 or a724996
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Include macOS, Bun, imsg, and selected runtime versions.
+      placeholder: macOS 26.5.1; Bun 1.3.14; imsg 0.14.1; Codex 0.146.1
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Describe the behavior using synthetic examples only.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      placeholder: |
+        1. Configure the synthetic tag @helper
+        2. Send a synthetic test request
+        3. Run s4imsg status
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Content-free diagnostics
+      description: Paste status or doctor output only after checking that it contains no private data.
+      render: shell
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy confirmation
+      options:
+        - label: I removed all real conversation content, identifiers, attachment paths, credentials, and provider output.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/eabnelson/s4imsg/security/advisories/new
+    about: Report vulnerabilities privately; never include conversation data in a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Suggest a focused improvement to s4imsg
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Describe the user need without including real conversation data.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Explain the smallest useful behavior and any security implications.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope confirmation
+      options:
+        - label: This keeps s4imsg independent of Studio Four.
+          required: true
+        - label: This request contains no private conversation data or participant identifiers.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## What changed
+
+Describe the user-visible behavior and why this is the smallest useful change.
+
+## Security and privacy
+
+Describe any change to participant authority, runtime permissions, conversation
+context, local storage, logging, or Messages access. Write `No change` when none
+applies.
+
+## Verification
+
+- [ ] `bun run typecheck`
+- [ ] `bun test`
+- [ ] `bun run build`
+- [ ] `bun run release:validate`
+- [ ] Fixtures, logs, and this PR contain no real conversation data or identifiers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,14 @@ permissions:
 jobs:
   build:
     runs-on: macos-15
+    permissions:
+      contents: read
+    outputs:
+      prerelease: ${{ steps.release-version.outputs.prerelease }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
@@ -23,10 +29,68 @@ jobs:
       - run: ./dist/s4imsg --version
       - run: ./dist/s4imsg --help
       - run: bun run release:validate
-      - run: shasum -a 256 dist/s4imsg > dist/s4imsg.sha256
+      - name: Verify tag matches package version
+        id: release-version
+        run: |
+          VERSION="$(bun -e 'import packageJson from "./package.json" with { type: "json" }; process.stdout.write(packageJson.version)')"
+          test "v$VERSION" = "$GITHUB_REF_NAME"
+          if [[ "$VERSION" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Verify owner qualification is complete
+        run: bun ./scripts/release-qualification.ts docs/RELEASE_QUALIFICATION.md "$GITHUB_REF_NAME"
+      - name: Create and verify checksum
+        working-directory: dist
+        run: |
+          shasum -a 256 s4imsg > s4imsg.sha256
+          shasum -a 256 -c s4imsg.sha256
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: s4imsg-macos
+          retention-days: 1
           path: |
             dist/s4imsg
             dist/s4imsg.sha256
+
+  publish:
+    needs: build
+    runs-on: macos-15
+    permissions:
+      contents: write
+    env:
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
+      IS_PRERELEASE: ${{ needs.build.outputs.prerelease }}
+    steps:
+      - name: Refuse to mutate an existing release
+        run: |
+          if gh api "repos/$GH_REPO/releases/tags/$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists; releases and their assets are immutable."
+            echo "If a previous attempt left a draft, delete that draft explicitly before rerunning."
+            exit 1
+          fi
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: s4imsg-macos
+          path: release-assets
+      - name: Verify downloaded checksum
+        working-directory: release-assets
+        run: shasum -a 256 -c s4imsg.sha256
+      - name: Create draft release
+        run: |
+          gh release create "$GITHUB_REF_NAME" --draft --generate-notes --verify-tag \
+            --prerelease="$IS_PRERELEASE" --title "s4imsg $GITHUB_REF_NAME"
+      - name: Upload and verify draft assets
+        run: |
+          gh release upload "$GITHUB_REF_NAME" \
+            release-assets/s4imsg release-assets/s4imsg.sha256
+
+          RELEASE_ID="$(gh api "repos/$GH_REPO/releases/tags/$GITHUB_REF_NAME" \
+            --jq 'select(.draft == true and ([.assets[].name] | sort == ["s4imsg", "s4imsg.sha256"])) | .id')"
+          test -n "$RELEASE_ID"
+      - name: Publish verified release
+        run: |
+          gh release edit "$GITHUB_REF_NAME" --draft=false
+          test "$(gh api "repos/$GH_REPO/releases/tags/$GITHUB_REF_NAME" --jq '.draft')" = "false"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,44 @@
 # Contributing
 
-Contributions are welcome after the first release contract is stable.
+Contributions are welcome. Please open a focused issue before starting a large
+behavioral change so the security and privacy contract can be discussed first.
+
+## Local development
+
+You need macOS, Bun 1.3.14 or newer, and the source-install requirements from
+the [README](README.md).
+
+```sh
+git clone https://github.com/eabnelson/s4imsg.git
+cd s4imsg
+bun install --frozen-lockfile
+bun run typecheck
+bun test
+bun run build
+bun run release:validate
+```
+
+The automated suite uses synthetic fixtures and does not read or send iMessages.
+Run the owner-only [live smoke checklist](docs/LIVE_SMOKE.md) only when a change
+affects the real Messages integration.
+
+## Project rules
 
 - Keep the project independent of Studio Four packages and services.
 - Use synthetic message fixtures only.
 - Add focused tests for behavior changes.
-- Run `bun test`, `bun run typecheck`, and `bun run release:validate` before
-  opening a pull request.
+- Never put message text, handles, chat identifiers, attachment paths,
+  credentials, or provider output in issues, fixtures, snapshots, or logs.
 - Do not add rich outbound Messages mutations without a separately reviewed
   product decision.
+
+## Pull requests
+
+- Keep each pull request small enough to review as one coherent change.
+- Explain user-visible behavior and security implications.
+- Run `bun run typecheck`, `bun test`, `bun run build`, and
+  `bun run release:validate` before opening it.
+- Do not commit generated `dist/` output or real local configuration.
+
+Report vulnerabilities through a private GitHub security advisory as described
+in [SECURITY.md](SECURITY.md), not through a public issue.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # s4imsg
 
+[![CI](https://github.com/eabnelson/s4imsg/actions/workflows/ci.yml/badge.svg)](https://github.com/eabnelson/s4imsg/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 `s4imsg` is a small, local macOS bridge between iMessage and the Codex or Claude
 Code CLI. Pick a tag such as `@helper`; when anyone uses it in an iMessage chat
 you have already participated in, the bridge gives one bounded, one-shot turn to
@@ -31,24 +34,26 @@ switch a chat into a repository you do not trust.
 - At least one authenticated [Codex CLI](https://github.com/openai/codex) or
   [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code/getting-started)
 
-Install `imsg` with its recommended Homebrew tap:
+## Quick start
+
+Install Bun and `imsg` if you do not already have them, then clone and run setup:
 
 ```sh
-brew install steipete/tap/imsg
+brew install oven-sh/bun/bun steipete/tap/imsg
+git clone https://github.com/eabnelson/s4imsg.git
+cd s4imsg
+bun install --frozen-lockfile
+bun run setup
 ```
+
+Codex or Claude Code must already be installed and signed in before `bun run
+setup`. Setup automatically detects both CLIs, lets you choose the primary and
+optional fallback, and validates that every selected runtime can complete an
+unattended tool call before installing anything.
 
 The ordinary `imsg` read, watch, and text-send path is sufficient. `s4imsg` does
 not require disabling System Integrity Protection or enabling `imsg`'s private
 IMCore bridge.
-
-## Install from source
-
-Clone this repository, then run:
-
-```sh
-bun install --frozen-lockfile
-bun run src/cli.ts setup
-```
 
 Setup asks for:
 
@@ -75,7 +80,8 @@ a number in the next tagged message to confirm one.
 
 After qualification, setup compiles a stable executable under
 `~/Library/Application Support/s4imsg/`, writes an owner-only configuration, and
-installs the `dev.s4imsg.agent` user LaunchAgent.
+installs the `dev.s4imsg.agent` user LaunchAgent. It finishes by printing the
+exact permission, `doctor`, and `status` steps for that Mac.
 
 ## macOS permissions
 
@@ -91,12 +97,15 @@ In System Settings → Privacy & Security:
 After installation, run:
 
 ```sh
-~/Library/Application\ Support/s4imsg/bin/s4imsg doctor
+S4IMSG="$HOME/Library/Application Support/s4imsg/bin/s4imsg"
+"$S4IMSG" doctor
+"$S4IMSG" status
 ```
 
-`doctor` performs real read/watch and runtime probes. It cannot test Messages
-Automation without sending a message, so complete the
-[live test-chat checklist](docs/LIVE_SMOKE.md) once.
+Wait for `doctor` to finish; its runtime probes can take around a minute. A
+healthy listener reports `listener running`, `database ready`, and `daemon
+ready`. `doctor` cannot test Messages Automation without sending a message, so
+complete the [live test-chat checklist](docs/LIVE_SMOKE.md) once.
 
 ## Use
 
@@ -129,13 +138,14 @@ attachment metadata, and tool results are not archived by `s4imsg`.
 ## Operations
 
 ```sh
-~/Library/Application\ Support/s4imsg/bin/s4imsg status
-~/Library/Application\ Support/s4imsg/bin/s4imsg status --chats
-~/Library/Application\ Support/s4imsg/bin/s4imsg doctor
-~/Library/Application\ Support/s4imsg/bin/s4imsg stop
-~/Library/Application\ Support/s4imsg/bin/s4imsg forget <opaque-chat-key>
-~/Library/Application\ Support/s4imsg/bin/s4imsg uninstall
-~/Library/Application\ Support/s4imsg/bin/s4imsg uninstall --purge --confirm-purge
+S4IMSG="$HOME/Library/Application Support/s4imsg/bin/s4imsg"
+"$S4IMSG" status
+"$S4IMSG" status --chats
+"$S4IMSG" doctor
+"$S4IMSG" stop
+"$S4IMSG" forget <opaque-chat-key>
+"$S4IMSG" uninstall
+"$S4IMSG" uninstall --purge --confirm-purge
 ```
 
 `status` reports only operational counts, including silently rate-limited events,
@@ -163,6 +173,43 @@ bun run src/cli.ts setup
 Setup replaces the stable executable atomically and preserves configuration and
 bounded memory. macOS may treat the replacement as a new privacy identity; run
 `doctor` again and toggle stale Full Disk Access entries off and on if needed.
+
+## Troubleshooting
+
+### `daemon failed` immediately after setup
+
+macOS can retain the permission record for a previous build while denying the
+new executable. In Full Disk Access, remove the existing `s4imsg` entry, add the
+exact installed executable again, and enable it. Press Command-Shift-G in the
+file picker and paste:
+
+```text
+~/Library/Application Support/s4imsg/bin/s4imsg
+```
+
+Then restart and check the service:
+
+```sh
+/bin/launchctl kickstart -k "gui/$(id -u)/dev.s4imsg.agent"
+sleep 3
+"$HOME/Library/Application Support/s4imsg/bin/s4imsg" status
+```
+
+### No reply arrives
+
+- Confirm the message is iMessage, not SMS or RCS.
+- Confirm this Mac owner previously sent a message in that chat.
+- Run `doctor` and resolve every failed check; degraded
+  `messages-send-automation` is expected until the first real send.
+- Open Messages once and approve its Automation prompt if macOS presents one.
+- Check `~/Library/Logs/s4imsg/daemon.log`; logs contain operational states, not
+  conversation content.
+
+### A self-chat appears duplicated
+
+Messages displays one self-chat message as an incoming and outgoing pair. That
+pair is expected. Two reply pairs indicate two agent sends and should be
+reported as a bug.
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,10 @@
 # Security
 
+## Supported versions
+
+Until the first stable release, security fixes are made on the latest `main`
+branch and included in the next tagged release. Older commits are not supported.
+
 ## Trust model
 
 The configured trigger tag is not authentication. Any current or future participant in an eligible
@@ -45,4 +50,7 @@ prompt injection risk, but are not authorization or process isolation.
 
 Do not include real message text, participant identifiers, chat identifiers,
 attachment paths, credentials, or provider output in a public report. Open a
-minimal private security advisory in the eventual GitHub repository.
+minimal [private GitHub security advisory](https://github.com/eabnelson/s4imsg/security/advisories/new).
+Include the affected version or commit, impact, and synthetic reproduction steps.
+You should receive an initial response within seven days. Please do not open a
+public issue until a fix and disclosure plan have been agreed.

--- a/docs/RELEASE_QUALIFICATION.md
+++ b/docs/RELEASE_QUALIFICATION.md
@@ -12,12 +12,14 @@ file records capability evidence, not private conversation data.
 | imsg | 0.14.1 | Protocol v1 initialize, database readiness, method qualification | Pass |
 | Codex CLI | 0.146.1 | Auth/help inspection and adapter fixtures | Pass |
 | Claude Code | 2.1.226 | Auth/help inspection and adapter fixtures | Pass |
-| Codex effective local probe | 0.146.1 | Existing configured MCP OAuth prevents turn startup | Blocked locally |
-| Claude effective local probe | 2.1.226 | Existing noninteractive policy denied temporary write | Blocked locally |
-| Messages Automation | Owner test chat | `docs/LIVE_SMOKE.md` | Pending |
-| Full tagged flow | Owner test chat | Core and multi-turn smoke | Pending |
+| Codex effective local probe | 0.146.1 | Setup noninteractive file-tool probe | Pass |
+| Claude effective local probe | 2.1.226 | Setup noninteractive file-tool probe | Pass |
+| Messages Automation | Owner self-chat, 2026-08-18 | Exactly one agent send; one expected mirrored display pair | Pass |
+| Self-chat mirror handling | Owner self-chat, 2026-08-18 | One tagged activation and one agent send | Pass |
+| Full remote tagged flow | Owner test chat | Remote-participant and multi-turn smoke | Pending |
 
-The matrix records versions tested on 2026-08-15. Capability checks, not version
+The automated matrix records versions tested on 2026-08-15 and the owner smoke
+evidence added on 2026-08-18. Capability checks, not version
 strings alone, determine whether setup and startup proceed.
 
 ## Automated release gates
@@ -38,6 +40,7 @@ strings alone, determine whether setup and startup proceed.
 ## Owner-only gate
 
 Run `docs/LIVE_SMOKE.md` after installing the exact release candidate. Replace
-the two Pending cells above with the date and Pass only after exactly-one reply,
-recent context, tagged continuity, restart suppression, and content-free logs are
-observed. Do not publish a GitHub release while either cell is Pending.
+the remaining Pending cell with the date and Pass only after a remote
+participant's exactly-one reply, recent context, tagged continuity, restart
+suppression, and content-free logs are observed. Do not publish a GitHub release
+while any cell is Pending or Blocked.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "description": "A local iMessage bridge for Codex and Claude Code",
   "type": "module",
   "license": "MIT",
+  "homepage": "https://github.com/eabnelson/s4imsg#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/eabnelson/s4imsg.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eabnelson/s4imsg/issues"
+  },
   "engines": {
     "bun": ">=1.3.14"
   },
@@ -19,6 +27,7 @@
   "packageManager": "bun@1.3.14",
   "scripts": {
     "build": "bun build ./src/cli.ts --compile --outfile ./dist/s4imsg",
+    "setup": "bun run ./src/cli.ts setup",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
     "test:integration": "bun test ./test/integration",

--- a/scripts/release-qualification.ts
+++ b/scripts/release-qualification.ts
@@ -1,0 +1,103 @@
+const expectedSurfaces = new Set([
+  "macOS",
+  "Bun",
+  "imsg",
+  "Codex CLI",
+  "Claude Code",
+  "Codex effective local probe",
+  "Claude effective local probe",
+  "Messages Automation",
+  "Self-chat mirror handling",
+  "Full remote tagged flow",
+]);
+const semverTag = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+function cellsFor(line: string): string[] | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("|") || !trimmed.endsWith("|")) return null;
+  return trimmed.slice(1, -1).split("|").map((cell) => cell.trim());
+}
+
+function matrixLines(markdown: string): string[] {
+  const lines = markdown.split(/\r?\n/);
+  const headings = lines
+    .map((line, index) => ({ index, line: line.trim() }))
+    .filter(({ line }) => line === "## Current matrix");
+  if (headings.length !== 1) {
+    throw new Error("release qualification must contain exactly one Current matrix section");
+  }
+
+  const sectionStart = headings[0]!.index + 1;
+  const sectionEnd = lines.findIndex(
+    (line, index) => index >= sectionStart && /^##\s+/.test(line.trim()),
+  );
+  const section = lines.slice(sectionStart, sectionEnd === -1 ? undefined : sectionEnd);
+  const headerIndex = section.findIndex((line) => line.trim().length > 0);
+  if (headerIndex === -1) throw new Error("release qualification matrix is missing");
+
+  const table: string[] = [];
+  for (const line of section.slice(headerIndex)) {
+    if (line.trim().length === 0) break;
+    table.push(line);
+  }
+  return table;
+}
+
+export function validateReleaseQualification(markdown: string, releaseTag: string): void {
+  if (!semverTag.test(releaseTag)) {
+    throw new Error(`release tag must be valid semver prefixed with v: ${releaseTag}`);
+  }
+
+  const lines = matrixLines(markdown);
+  const header = cellsFor(lines[0] ?? "");
+  if (header === null || header.join("|") !== "Surface|Qualified version|Evidence|Status") {
+    throw new Error("release qualification matrix has an unexpected header");
+  }
+
+  const divider = cellsFor(lines[1] ?? "");
+  if (divider === null || divider.length !== 4 || divider.some((cell) => !/^:?-{3,}:?$/.test(cell))) {
+    throw new Error("release qualification matrix has a malformed divider");
+  }
+
+  const seen = new Set<string>();
+  for (const [index, line] of lines.slice(2).entries()) {
+    const cells = cellsFor(line);
+    if (cells === null || cells.length !== 4 || cells.some((cell) => cell.length === 0)) {
+      throw new Error(`malformed qualification row at matrix line ${index + 3}`);
+    }
+
+    const [surface, qualifiedVersion, _evidence, status] = cells as [string, string, string, string];
+    if (!expectedSurfaces.has(surface)) {
+      throw new Error(`unknown qualification row: ${surface}`);
+    }
+    if (seen.has(surface)) throw new Error(`duplicate qualification row: ${surface}`);
+    seen.add(surface);
+
+    if (status !== "Pass") {
+      throw new Error(`${surface} status must be Pass, received ${status}`);
+    }
+    if (surface === "Full remote tagged flow" && qualifiedVersion !== releaseTag) {
+      throw new Error(`Full remote tagged flow must be qualified for exact release tag ${releaseTag}`);
+    }
+  }
+
+  for (const surface of expectedSurfaces) {
+    if (!seen.has(surface)) throw new Error(`missing expected qualification row: ${surface}`);
+  }
+}
+
+if (import.meta.main) {
+  const [path, releaseTag] = Bun.argv.slice(2);
+  if (path === undefined || releaseTag === undefined) {
+    console.error("usage: bun scripts/release-qualification.ts <matrix-path> <release-tag>");
+    process.exit(2);
+  }
+
+  try {
+    validateReleaseQualification(await Bun.file(path).text(), releaseTag);
+    console.log(`release qualification passed for ${releaseTag}`);
+  } catch (error) {
+    console.error(`release qualification failed: ${error instanceof Error ? error.message : error}`);
+    process.exit(1);
+  }
+}

--- a/scripts/release-validate.ts
+++ b/scripts/release-validate.ts
@@ -25,6 +25,12 @@ const failures: string[] = [];
 
 if (packageJson.name !== "s4imsg") failures.push("package name must be s4imsg");
 if (packageJson.license !== "MIT") failures.push("package license must be MIT");
+if (packageJson.homepage !== "https://github.com/eabnelson/s4imsg#readme") {
+  failures.push("package homepage must point to the public repository");
+}
+if (packageJson.repository?.url !== "git+https://github.com/eabnelson/s4imsg.git") {
+  failures.push("package repository metadata is missing");
+}
 if ("private" in packageJson && packageJson.private === true) {
   failures.push("package must not be marked private");
 }
@@ -41,6 +47,10 @@ for (const required of [
   "docs/LIVE_SMOKE.md",
   "docs/RELEASE_QUALIFICATION.md",
   ".github/dependabot.yml",
+  ".github/ISSUE_TEMPLATE/bug_report.yml",
+  ".github/ISSUE_TEMPLATE/feature_request.yml",
+  ".github/ISSUE_TEMPLATE/config.yml",
+  ".github/PULL_REQUEST_TEMPLATE.md",
   ".github/workflows/ci.yml",
   ".github/workflows/release.yml",
 ]) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import {
   loadExistingSetupDefaults,
   prepareSetupConfig,
   resolveWorkspaceSelection,
+  setupCompletionMessage,
   uninstallInstallation,
   runCommand,
 } from "./macos/setup";
@@ -187,9 +188,7 @@ async function runSetup(): Promise<number> {
       paths,
       ...(sourceInvocation ? { repositoryRoot: dirname(dirname(resolve(sourceEntry))) } : {}),
     });
-    console.log(
-      `s4imsg installed. Run \`"${paths.executablePath}" doctor\` to verify local permissions.`,
-    );
+    console.log(setupCompletionMessage(paths, config.tag));
     return 0;
   } finally {
     prompt.close();

--- a/src/macos/setup.ts
+++ b/src/macos/setup.ts
@@ -32,6 +32,28 @@ export interface ExistingSetupDefaults {
   workingDirectory: string;
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+export function setupCompletionMessage(
+  paths: Pick<S4imsgPaths, "executablePath">,
+  tag: string,
+): string {
+  const executable = shellQuote(paths.executablePath);
+  return `s4imsg installed.
+
+Finish setup:
+1. In System Settings > Privacy & Security > Full Disk Access, add this exact file:
+   ${paths.executablePath}
+   After an upgrade, remove and re-add a stale s4imsg entry if macOS no longer recognizes it.
+2. Wait for the checks to finish:
+   ${executable} doctor
+3. Confirm the background listener is ready:
+   ${executable} status
+4. Send ${tag} ping in an iMessage chat where this Mac owner has already sent a message.`;
+}
+
 export async function loadExistingSetupDefaults(
   configPath: string,
 ): Promise<ExistingSetupDefaults | null> {

--- a/test/unit/release-qualification.test.ts
+++ b/test/unit/release-qualification.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { validateReleaseQualification } from "../../scripts/release-qualification";
+
+const surfaces = [
+  "macOS",
+  "Bun",
+  "imsg",
+  "Codex CLI",
+  "Claude Code",
+  "Codex effective local probe",
+  "Claude effective local probe",
+  "Messages Automation",
+  "Self-chat mirror handling",
+  "Full remote tagged flow",
+] as const;
+
+function matrix(
+  overrides: Partial<Record<(typeof surfaces)[number], Partial<{
+    evidence: string;
+    status: string;
+    version: string;
+  }>>> = {},
+): string {
+  const rows = surfaces.map((surface) => {
+    const override = overrides[surface] ?? {};
+    const version = override.version
+      ?? (surface === "Full remote tagged flow" ? "v0.1.0" : "qualified-version");
+    return `| ${surface} | ${version} | ${override.evidence ?? "qualification evidence"} | ${override.status ?? "Pass"} |`;
+  });
+
+  return [
+    "# Release qualification",
+    "",
+    "## Current matrix",
+    "",
+    "| Surface | Qualified version | Evidence | Status |",
+    "| --- | --- | --- | --- |",
+    ...rows,
+    "",
+    "## Owner-only gate",
+  ].join("\n");
+}
+
+describe("release qualification matrix", () => {
+  test("accepts every expected row exactly once when all statuses pass", () => {
+    expect(() => validateReleaseQualification(matrix(), "v0.1.0")).not.toThrow();
+  });
+
+  for (const status of ["Pending", "Fail"]) {
+    test(`rejects a ${status} status`, () => {
+      expect(() => validateReleaseQualification(matrix({ Bun: { status } }), "v0.1.0"))
+        .toThrow(`Bun status must be Pass, received ${status}`);
+    });
+  }
+
+  test("rejects a missing expected row", () => {
+    const markdown = matrix().replace(
+      "| imsg | qualified-version | qualification evidence | Pass |\n",
+      "",
+    );
+    expect(() => validateReleaseQualification(markdown, "v0.1.0"))
+      .toThrow("missing expected qualification row: imsg");
+  });
+
+  test("rejects a duplicate expected row", () => {
+    const row = "| Codex CLI | qualified-version | qualification evidence | Pass |";
+    const markdown = matrix().replace(row, `${row}\n${row}`);
+    expect(() => validateReleaseQualification(markdown, "v0.1.0"))
+      .toThrow("duplicate qualification row: Codex CLI");
+  });
+
+  test("rejects remote-flow evidence for a stale release tag", () => {
+    expect(() => validateReleaseQualification(
+      matrix({ "Full remote tagged flow": { version: "v0.0.9" } }),
+      "v0.1.0",
+    )).toThrow("Full remote tagged flow must be qualified for exact release tag v0.1.0");
+  });
+
+  test("trims cells before validating them", () => {
+    const markdown = matrix().replace(
+      "| Bun | qualified-version | qualification evidence | Pass |",
+      "|   Bun   |   qualified-version   |   qualification evidence   |   Pass   |",
+    );
+    expect(() => validateReleaseQualification(markdown, "v0.1.0")).not.toThrow();
+  });
+
+  test("rejects unknown rows", () => {
+    const markdown = matrix().replace(
+      "| Full remote tagged flow |",
+      "| Unknown surface | qualified-version | qualification evidence | Pass |\n| Full remote tagged flow |",
+    );
+    expect(() => validateReleaseQualification(markdown, "v0.1.0"))
+      .toThrow("unknown qualification row: Unknown surface");
+  });
+
+  test("rejects malformed rows", () => {
+    const markdown = matrix().replace(
+      "| imsg | qualified-version | qualification evidence | Pass |",
+      "| imsg | qualified-version | Pass |",
+    );
+    expect(() => validateReleaseQualification(markdown, "v0.1.0"))
+      .toThrow("malformed qualification row");
+  });
+});

--- a/test/unit/setup.test.ts
+++ b/test/unit/setup.test.ts
@@ -13,6 +13,7 @@ import {
   loadExistingSetupDefaults,
   prepareSetupConfig,
   resolveWorkspaceSelection,
+  setupCompletionMessage,
   uninstallInstallation,
 } from "../../src/macos/setup";
 
@@ -25,6 +26,37 @@ afterEach(async () => {
 });
 
 describe("setup discovery", () => {
+  test("gives copy-safe post-install permission and verification steps", () => {
+    const message = setupCompletionMessage(
+      {
+        executablePath: "/Users/example/Library/Application Support/s4imsg/bin/s4imsg",
+      },
+      "@helper",
+    );
+
+    expect(message).toContain("s4imsg installed");
+    expect(message).toContain("Full Disk Access");
+    expect(message).toContain("remove and re-add");
+    expect(message).toContain(
+      "'/Users/example/Library/Application Support/s4imsg/bin/s4imsg' doctor",
+    );
+    expect(message).toContain(
+      "'/Users/example/Library/Application Support/s4imsg/bin/s4imsg' status",
+    );
+    expect(message).toContain("@helper ping");
+  });
+
+  test("shell-quotes an installed path containing an apostrophe", () => {
+    const message = setupCompletionMessage(
+      { executablePath: "/Users/O'Neil/Library/Application Support/s4imsg/bin/s4imsg" },
+      "@helper",
+    );
+
+    expect(message).toContain(
+      "'/Users/O'\\''Neil/Library/Application Support/s4imsg/bin/s4imsg' doctor",
+    );
+  });
+
   test("accepts one runtime and records absolute command paths", () => {
     const commands = new Map([
       ["imsg", "/opt/homebrew/bin/imsg"],


### PR DESCRIPTION
## What changed

s4imsg now has a clear public first-run path, contributor intake that protects conversation privacy, and a release pipeline that publishes only fully qualified artifacts.

- Setup prints copy-safe Full Disk Access, `doctor`, `status`, and first-message instructions for the installed executable.
- The README now leads with a complete source install, expected healthy state, self-chat behavior, and fixes for the failure modes encountered during live testing.
- Public bug, feature, pull request, contribution, and private security-reporting paths are ready for outside users.
- Tagged releases require an exact, complete qualification matrix. Build credentials are read-only, checksums are verified after artifact transfer, and assets are published from a verified draft without overwriting an existing release.

## Security and privacy

This does not broaden participant authority, runtime permissions, conversation context, local storage, logging, or Messages access. Public report templates explicitly prohibit real conversation data and direct vulnerabilities to private advisories. The release workflow separates unprivileged build work from the short-lived job with `contents: write`.

## Verification

- [x] `bun run typecheck`
- [x] `bun test` — 142 tests, 0 failures
- [x] `bun run build` — compiled CLI reports `s4imsg 0.1.0`
- [x] `bun run release:validate`
- [x] GitHub workflow and issue-form YAML parses successfully
- [x] Built artifact checksum verifies after generation
- [x] Fixtures, logs, and this PR contain no real conversation data or identifiers

The negative release check also behaves as intended: `v0.1.0` is blocked while the remote-participant live smoke row remains `Pending`.

## Post-deploy monitoring and validation

- During the first release and for 24 hours after it, the repository owner should verify that the Release workflow logs `release qualification passed`, verifies `s4imsg: OK`, and publishes exactly `s4imsg` plus `s4imsg.sha256`.
- Healthy local installs should report `listener running`, `database ready`, and `daemon ready`, with one reply for both a self-chat and a remote-participant tagged smoke test.
- Treat qualification failures, asset mismatches, `daemon failed`, or duplicate agent replies as rollback triggers. Delete an unpublished draft and its tag before retrying; never replace an already published version—cut a patch release instead.
