### PR TITLE
Recover immutable tag publication safely

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,10 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
-          ref: ${{ inputs.release_tag || github.ref }}
+          ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
+      - name: Verify recovery checkout is the immutable tag
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: test "$(git rev-parse HEAD)" = "$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")"
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing immutable tag to rebuild and publish
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -11,16 +17,20 @@ permissions:
 jobs:
   build:
     runs-on: macos-15
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
     permissions:
       contents: read
     outputs:
       package-file: ${{ steps.release-version.outputs.package-file }}
       package-version: ${{ steps.release-version.outputs.package-version }}
       prerelease: ${{ steps.release-version.outputs.prerelease }}
+      release-tag: ${{ steps.release-version.outputs.release-tag }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
+          ref: ${{ inputs.release_tag || github.ref }}
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
@@ -41,17 +51,18 @@ jobs:
         run: |
           VERSION="$(bun -e 'import packageJson from "./package.json" with { type: "json" }; process.stdout.write(packageJson.version)')"
           PACKAGE_VERSION="$(bun -e 'import packageJson from "./packages/messages/package.json" with { type: "json" }; process.stdout.write(packageJson.version)')"
-          test "v$VERSION" = "$GITHUB_REF_NAME"
+          test "v$VERSION" = "$RELEASE_TAG"
           test "$VERSION" = "$PACKAGE_VERSION"
           echo "package-file=pronto-imessage-$PACKAGE_VERSION.tgz" >> "$GITHUB_OUTPUT"
           echo "package-version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "release-tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           if [[ "$VERSION" == *-* ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Verify owner qualification is complete
-        run: bun ./scripts/release-qualification.ts docs/RELEASE_QUALIFICATION.md "$GITHUB_REF_NAME"
+        run: bun ./scripts/release-qualification.ts docs/RELEASE_QUALIFICATION.md "$RELEASE_TAG"
       - name: Create and verify checksum
         run: |
           npm pack ./packages/messages --pack-destination ./dist
@@ -88,16 +99,17 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       PACKAGE_FILE: ${{ needs.build.outputs.package-file }}
       PACKAGE_VERSION: ${{ needs.build.outputs.package-version }}
+      RELEASE_TAG: ${{ needs.build.outputs.release-tag }}
     steps:
       - name: Refuse to mutate an existing release
         run: |
           EXISTING_RELEASE_ID="$(
             gh api --paginate "repos/$GH_REPO/releases?per_page=100" |
-              jq -r --arg tag "$GITHUB_REF_NAME" \
+              jq -r --arg tag "$RELEASE_TAG" \
                 '.[] | select(.tag_name == $tag) | .id'
           )"
           if [[ -n "$EXISTING_RELEASE_ID" ]]; then
-            echo "Release $GITHUB_REF_NAME already exists; releases and their assets are immutable."
+            echo "Release $RELEASE_TAG already exists; releases and their assets are immutable."
             echo "If a previous attempt left a draft, delete that draft explicitly before rerunning."
             exit 1
           fi
@@ -117,18 +129,18 @@ jobs:
           sha256sum -c pronto-imessage.sha256
       - name: Create draft release
         run: |
-          gh release create "$GITHUB_REF_NAME" --draft --generate-notes --verify-tag \
-            --prerelease="$IS_PRERELEASE" --title "Pronto $GITHUB_REF_NAME"
+          gh release create "$RELEASE_TAG" --draft --generate-notes --verify-tag \
+            --prerelease="$IS_PRERELEASE" --title "Pronto $RELEASE_TAG"
       - name: Upload and verify draft assets
         run: |
-          gh release upload "$GITHUB_REF_NAME" \
+          gh release upload "$RELEASE_TAG" \
             release-assets/pronto release-assets/pronto.sha256 \
             release-assets/s4imsg release-assets/s4imsg.sha256 \
             "release-assets/$PACKAGE_FILE" release-assets/pronto-imessage.sha256
 
           RELEASE_ID="$(
             gh api --paginate "repos/$GH_REPO/releases?per_page=100" |
-              jq -r --arg tag "$GITHUB_REF_NAME" --arg package "$PACKAGE_FILE" '
+              jq -r --arg tag "$RELEASE_TAG" --arg package "$PACKAGE_FILE" '
                 .[] |
                 select(
                   .tag_name == $tag and
@@ -146,10 +158,10 @@ jobs:
           if [[ -n "$REMOTE_SHASUM" ]]; then
             test "$REMOTE_SHASUM" = "$LOCAL_SHASUM"
           else
-            npm publish "release-assets/$PACKAGE_FILE" --provenance --access public
+            npm publish "./release-assets/$PACKAGE_FILE" --provenance --access public
           fi
           test "$(npm view "pronto-imessage@$PACKAGE_VERSION" version)" = "$PACKAGE_VERSION"
       - name: Publish verified release
         run: |
-          gh release edit "$GITHUB_REF_NAME" --draft=false
-          test "$(gh api "repos/$GH_REPO/releases/tags/$GITHUB_REF_NAME" --jq '.draft')" = "false"
+          gh release edit "$RELEASE_TAG" --draft=false
+          test "$(gh api "repos/$GH_REPO/releases/tags/$RELEASE_TAG" --jq '.draft')" = "false"

--- a/scripts/release-workflow-validation.ts
+++ b/scripts/release-workflow-validation.ts
@@ -1,12 +1,14 @@
 const REQUIRED_CONTROLS = [
   [
-    'npm publish "release-assets/$PACKAGE_FILE" --provenance --access public',
+    'npm publish "./release-assets/$PACKAGE_FILE" --provenance --access public',
     "npm publication with provenance",
   ],
   ["NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}", "npm authentication"],
   ["id-token: write", "OIDC provenance permission"],
   ["dist/pronto-imessage-*.tgz", "package release artifact"],
   ["sha256sum -c pronto-imessage.sha256", "downloaded package checksum verification"],
+  ["workflow_dispatch:", "manual immutable-tag recovery"],
+  ["ref: ${{ inputs.release_tag || github.ref }}", "tag-pinned recovery checkout"],
 ] as const;
 
 const ORDERED_STEPS = [

--- a/scripts/release-workflow-validation.ts
+++ b/scripts/release-workflow-validation.ts
@@ -8,7 +8,14 @@ const REQUIRED_CONTROLS = [
   ["dist/pronto-imessage-*.tgz", "package release artifact"],
   ["sha256sum -c pronto-imessage.sha256", "downloaded package checksum verification"],
   ["workflow_dispatch:", "manual immutable-tag recovery"],
-  ["ref: ${{ inputs.release_tag || github.ref }}", "tag-pinned recovery checkout"],
+  [
+    "ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.ref }}",
+    "tag-pinned recovery checkout",
+  ],
+  [
+    'git rev-parse "refs/tags/$RELEASE_TAG^{commit}"',
+    "peeled recovery tag verification",
+  ],
 ] as const;
 
 const ORDERED_STEPS = [

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -16,8 +16,8 @@ describe("release workflow", () => {
     );
 
     expect(listLookups).toHaveLength(2);
-    expect(beforePublish).not.toContain("releases/tags/$GITHUB_REF_NAME");
-    expect(beforePublish).toContain('--arg tag "$GITHUB_REF_NAME"');
+    expect(beforePublish).not.toContain("releases/tags/$RELEASE_TAG");
+    expect(beforePublish).toContain('--arg tag "$RELEASE_TAG"');
     expect(beforePublish).toContain(".tag_name == $tag");
     expect(beforePublish).toContain(".draft == true");
     expect(beforePublish).toContain('([.assets[].name] | sort) == ([');
@@ -31,10 +31,10 @@ describe("release workflow", () => {
     const workflow = await releaseWorkflow();
 
     expect(workflow).toContain("Refuse to mutate an existing release");
-    expect(workflow).toContain("gh release create \"$GITHUB_REF_NAME\" --draft");
-    expect(workflow).toContain('gh release edit "$GITHUB_REF_NAME" --draft=false');
+    expect(workflow).toContain("gh release create \"$RELEASE_TAG\" --draft");
+    expect(workflow).toContain('gh release edit "$RELEASE_TAG" --draft=false');
     expect(workflow).toContain(
-      'gh api "repos/$GH_REPO/releases/tags/$GITHUB_REF_NAME" --jq \'.draft\'',
+      'gh api "repos/$GH_REPO/releases/tags/$RELEASE_TAG" --jq \'.draft\'',
     );
     expect(workflow).toContain('test "$REMOTE_SHASUM" = "$LOCAL_SHASUM"');
   });
@@ -47,11 +47,13 @@ describe("release workflow", () => {
   test("rejects missing publication controls and reordered publication", async () => {
     const workflow = await releaseWorkflow();
     for (const control of [
-      'npm publish "release-assets/$PACKAGE_FILE" --provenance --access public',
+      'npm publish "./release-assets/$PACKAGE_FILE" --provenance --access public',
       "NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}",
       "id-token: write",
       "dist/pronto-imessage-*.tgz",
       "sha256sum -c pronto-imessage.sha256",
+      "workflow_dispatch:",
+      "ref: ${{ inputs.release_tag || github.ref }}",
     ]) {
       expect(releaseWorkflowViolations(workflow.replace(control, "removed-control")))
         .not.toEqual([]);
@@ -70,5 +72,18 @@ describe("release workflow", () => {
     expect(releaseWorkflowViolations(unverifiedDraft)).toContain(
       "release workflow step is out of order: - name: Create draft release",
     );
+  });
+
+  test("manual recovery rebuilds an explicit immutable tag", async () => {
+    const workflow = await releaseWorkflow();
+
+    expect(workflow).toContain("release_tag:");
+    expect(workflow).toContain("RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}");
+    expect(workflow).toContain("ref: ${{ inputs.release_tag || github.ref }}");
+    expect(workflow).toContain('test "v$VERSION" = "$RELEASE_TAG"');
+    expect(workflow).toContain('echo "release-tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"');
+    expect(workflow).toContain("RELEASE_TAG: ${{ needs.build.outputs.release-tag }}");
+    expect(workflow).toContain('--title "Pronto $RELEASE_TAG"');
+    expect(workflow).not.toContain("$GITHUB_REF_NAME");
   });
 });

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -53,7 +53,8 @@ describe("release workflow", () => {
       "dist/pronto-imessage-*.tgz",
       "sha256sum -c pronto-imessage.sha256",
       "workflow_dispatch:",
-      "ref: ${{ inputs.release_tag || github.ref }}",
+      "ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.ref }}",
+      'git rev-parse "refs/tags/$RELEASE_TAG^{commit}"',
     ]) {
       expect(releaseWorkflowViolations(workflow.replace(control, "removed-control")))
         .not.toEqual([]);
@@ -79,7 +80,11 @@ describe("release workflow", () => {
 
     expect(workflow).toContain("release_tag:");
     expect(workflow).toContain("RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}");
-    expect(workflow).toContain("ref: ${{ inputs.release_tag || github.ref }}");
+    expect(workflow).toContain(
+      "ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.ref }}",
+    );
+    expect(workflow).toContain("Verify recovery checkout is the immutable tag");
+    expect(workflow).toContain('git rev-parse "refs/tags/$RELEASE_TAG^{commit}"');
     expect(workflow).toContain('test "v$VERSION" = "$RELEASE_TAG"');
     expect(workflow).toContain('echo "release-tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"');
     expect(workflow).toContain("RELEASE_TAG: ${{ needs.build.outputs.release-tag }}");


### PR DESCRIPTION
## Summary

- publish the generated tarball through an explicit local path so npm does not parse it as a Git dependency
- add a manual recovery trigger that checks out and rebuilds one explicit immutable release tag
- pass the resolved tag through qualification, draft verification, npm publication, and final release publication
- add release-policy coverage for the recovery path

## Verification

- 221 tests pass
- TypeScript typecheck passes
- release validation passes
- targeted release workflow tests pass

## Recovery

After merge, delete only failed private draft release 381433669 and dispatch this workflow for the unchanged v0.1.0 tag. npm currently has no pronto-imessage@0.1.0 version.