### PR TITLE
fix: tolerate npm registry propagation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,13 @@ jobs:
           else
             npm publish "./release-assets/$PACKAGE_FILE" --provenance --access public
           fi
-          test "$(npm view "pronto-imessage@$PACKAGE_VERSION" version)" = "$PACKAGE_VERSION"
+          REMOTE_VERSION=""
+          for ATTEMPT in {1..12}; do
+            REMOTE_VERSION="$(npm view "pronto-imessage@$PACKAGE_VERSION" version 2>/dev/null || true)"
+            [[ "$REMOTE_VERSION" = "$PACKAGE_VERSION" ]] && break
+            sleep 5
+          done
+          test "$REMOTE_VERSION" = "$PACKAGE_VERSION"
       - name: Publish verified release
         run: |
           gh release edit "$RELEASE_TAG" --draft=false

--- a/scripts/release-workflow-validation.ts
+++ b/scripts/release-workflow-validation.ts
@@ -5,6 +5,7 @@ const REQUIRED_CONTROLS = [
   ],
   ["NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}", "npm authentication"],
   ["id-token: write", "OIDC provenance permission"],
+  ["for ATTEMPT in {1..12}; do", "npm registry propagation retry"],
   ["dist/pronto-imessage-*.tgz", "package release artifact"],
   ["sha256sum -c pronto-imessage.sha256", "downloaded package checksum verification"],
   ["workflow_dispatch:", "manual immutable-tag recovery"],

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -60,6 +60,7 @@ describe("release workflow", () => {
       'npm publish "./release-assets/$PACKAGE_FILE" --provenance --access public',
       "NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}",
       "id-token: write",
+      "for ATTEMPT in {1..12}; do",
       "dist/pronto-imessage-*.tgz",
       "sha256sum -c pronto-imessage.sha256",
       "workflow_dispatch:",

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -39,6 +39,16 @@ describe("release workflow", () => {
     expect(workflow).toContain('test "$REMOTE_SHASUM" = "$LOCAL_SHASUM"');
   });
 
+  test("retries npm verification while a new version propagates", async () => {
+    const workflow = await releaseWorkflow();
+
+    expect(workflow).toContain("for ATTEMPT in {1..12}; do");
+    expect(workflow).toContain('REMOTE_VERSION="$(npm view "pronto-imessage@$PACKAGE_VERSION" version 2>/dev/null || true)"');
+    expect(workflow).toContain('[[ "$REMOTE_VERSION" = "$PACKAGE_VERSION" ]] && break');
+    expect(workflow).toContain("sleep 5");
+    expect(workflow).toContain('test "$REMOTE_VERSION" = "$PACKAGE_VERSION"');
+  });
+
   test("orders qualification, draft verification, package publication, and release publication", async () => {
     const workflow = await releaseWorkflow();
     expect(releaseWorkflowViolations(workflow)).toEqual([]);


### PR DESCRIPTION
## Summary
- retry npm version verification for up to one minute after publication
- keep checksum matching and release publication fail-closed
- validate and test the propagation guard

## Verification
- `bun test` (222 pass)
- `bun run typecheck`
- `bun run release:validate`

Branding: off