### PR TITLE
Deepen the public Messages consumer contract

### DIFF
--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -12,3 +12,11 @@ Public implementation references:
 Studio Four was used only to identify product behavior worth preserving. Its
 files, implementation details, fixtures, and tests are not inputs to this
 repository's source history.
+
+The consumer routing contract added for `pronto-imessage` 0.2.0 was derived
+from consumer-neutral behavior: exact account-and-conversation resolution,
+bounded scoped access, provider delivery classification, and submission of one
+consumer-staged outbound file. It was independently implemented in this public
+repository and verified with synthetic public transcript and fault fixtures.
+No private consumer imports, source history, fixtures, identifiers, or domain
+models were used.

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "pronto-cli",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "bin": {
         "pronto": "./src/cli.ts",
         "s4imsg": "./src/legacy-cli.ts",
@@ -23,7 +23,7 @@
     },
     "packages/messages": {
       "name": "pronto-imessage",
-      "version": "0.1.0",
+      "version": "0.2.0",
     },
   },
   "packages": {

--- a/docs/RELEASE_QUALIFICATION.md
+++ b/docs/RELEASE_QUALIFICATION.md
@@ -17,7 +17,7 @@ file records capability evidence, not private conversation data.
 | Claude effective local probe | 2.1.226 | Setup noninteractive file-tool probe | Pass |
 | Messages Automation | Owner test chats, 2026-09-02 | Exactly one self-chat send and one RCS send; expected self-chat display mirror only | Pass |
 | Self-chat mirror handling | Owner self-chat, 2026-09-02 | One tagged activation and one agent send with no echo turn | Pass |
-| Full remote tagged flow | v0.1.0 | RCS exact reply, recent context, tagged continuity, restart suppression, forget, and content-free logs on 2026-09-02 | Pass |
+| Full remote tagged flow | v0.2.0 | Awaiting one exact-release remote canary after the consumer routing contract change | Pending |
 
 The automated matrix and owner smoke record versions tested on 2026-09-02.
 Capability checks, not version

--- a/docs/adr/0004-submit-one-consumer-staged-outbound-file.md
+++ b/docs/adr/0004-submit-one-consumer-staged-outbound-file.md
@@ -1,0 +1,26 @@
+---
+status: accepted
+---
+
+# Allow one consumer-staged outbound file
+
+The public Messages module may submit one absolute local file path with a reply
+to an exact module-issued conversation reference. The consumer owns permission
+to use the file, stages it outside provider-controlled storage, and removes it
+after the delivery outcome settles. Pronto owns exact provider routing and
+classifies the send as confirmed, ambiguous, or failed using the same rules as
+text replies.
+
+## Consequences
+
+The package rejects relative paths and does not expose inbound attachment paths
+or arbitrary Messages search. This decision does not add multiple attachments,
+reactions, edits, unsend, typing indicators, effects, group administration, or
+other rich Messages mutations. Each such capability still requires its own
+reviewed product decision.
+
+An ambiguous result means the provider may have accepted the submission and a
+consumer must not replay it automatically. Authorization, file validation,
+staging, retention, cleanup, and user-facing audit remain consumer policy;
+Pronto accepts only the already-authorized, staged absolute path at its narrow
+provider boundary.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-workspace",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A local iMessage bridge for Codex and Claude Code",
   "type": "module",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/messages/README.md
+++ b/packages/messages/README.md
@@ -45,6 +45,19 @@ The package binds durable checkpoints to a fingerprint of the current Messages d
 
 Every observed conversation carries a module-issued, versioned, tamper-evident reference with an expiry. References are process-local by default. A consumer with durable queued work can provide a stable owner-private `referenceKey` of at least 32 bytes; that permits an unexpired observed reference to be revalidated after restart without granting access to a different chat. Rotating the key invalidates outstanding references. History requires that exact reference plus an explicit message, row, byte, and RPC-call budget. Pagination continuations remain bound to the same conversation capability and database generation. They cannot be used to search another conversation.
 
+When `conversationFacts.routing` is present, it contains the exact provider
+conversation, account, destination, group, and roster facts jointly verified
+from the anchored message and chat catalog. Consumers that require those facts
+must fail closed when the optional routing projection is absent. Durable local
+work can call `resolveConversation` with an already-authorized exact account ID
+and conversation ID; the module performs only an exact bounded lookup and
+returns a fresh scoped reference or `null`. It never exposes catalog browsing or
+fuzzy/global search.
+
 Attachment metadata never exposes the Messages source path. Available attachments carry an expiring sealed reference. `materializeAttachment` revalidates the conversation, database generation, provider metadata, containment under the Messages attachments root, regular-file identity, size, and MIME evidence before copying bytes into owner-private scratch. The returned scratch file has an explicit `dispose()` lifecycle.
+
+`reply` optionally accepts one absolute, consumer-staged `filePath`. Routing,
+submission ambiguity, and retry classification remain owned by this module;
+the consumer remains responsible for authorizing and cleaning its staged file.
 
 The package root exposes normalized, versioned provider facts and delivery outcomes. Raw JSON-RPC methods, database paths, and payloads remain internal. The package is standard ESM and supports current Node.js and Bun consumers; the standalone `pronto` CLI is one ordinary workspace consumer.

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-imessage",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Reusable local Apple Messages transport for Pronto consumers",
   "type": "module",
   "license": "MIT",

--- a/packages/messages/src/index.ts
+++ b/packages/messages/src/index.ts
@@ -546,6 +546,7 @@ class ProntoMessagesClient implements ProntoMessages {
       facts.routing?.accountId !== input.accountId ||
       facts.routing.conversationId !== input.conversationId
     ) return null;
+    if (await this.#refreshGeneration() !== qualification.databaseGeneration) return null;
     return {
       conversation: this.#scoped.issueConversation(
         chat.id,
@@ -606,6 +607,10 @@ class ProntoMessagesClient implements ProntoMessages {
       rawMessage,
       generation,
     ));
+    const enrichedGeneration = await within(async () => await this.#refreshGeneration());
+    if (enrichedGeneration !== generation) {
+      throw new RecoveryBoundaryError("database-generation-changed", budget?.rows ?? 0);
+    }
     this.#rememberOutgoing(scopedEvent);
     const deliveryKey = `${generation}:${rowId}`;
     const existingDelivery = this.#inFlightDeliveries.get(deliveryKey);

--- a/packages/messages/src/index.ts
+++ b/packages/messages/src/index.ts
@@ -5,6 +5,7 @@ import {
   type RpcNotification,
 } from "./internal/rpc.js";
 import { createHash } from "node:crypto";
+import { isAbsolute } from "node:path";
 import {
   databasePath,
   normalizeConversationFacts,
@@ -33,6 +34,7 @@ import type {
   MessagesQualification,
   MessagesRecoveryOutcome,
   MessagesRecoveryReason,
+  ResolvedConversation,
   MessagesSubscription,
   ProntoMessages,
 } from "./types.js";
@@ -56,7 +58,15 @@ export type {
   MessagesSubscription,
   ProntoMessages,
   MaterializedAttachment,
+  ResolvedConversation,
 } from "./types.js";
+
+const CHAT_CATALOG_LIMITS = [128, 512, 2_048, 4_096] as const;
+
+function safeProviderCoordinate(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= 1_024 &&
+    !/[\u0000-\u001f]/u.test(value);
+}
 
 function messageDateMs(value: string | null): number | null {
   if (value === null) return null;
@@ -481,6 +491,9 @@ class ProntoMessagesClient implements ProntoMessages {
   }
 
   async reply(input: Parameters<ProntoMessages["reply"]>[0]): Promise<DeliveryOutcome> {
+    if (input.filePath !== undefined && !isAbsolute(input.filePath)) {
+      return { retryable: false, status: "failed" };
+    }
     const conversation = await this.#scoped.conversation(input.conversation, true).catch((error) => {
       if (error instanceof ConversationReferenceExpiredError) {
         return null;
@@ -491,6 +504,7 @@ class ProntoMessagesClient implements ProntoMessages {
     try {
       const result = record(await this.#rpc.request("send", {
         chat_id: conversation.chatId,
+        ...(input.filePath === undefined ? {} : { file: input.filePath }),
         text: input.text,
       }));
       if (result.ok !== true) return { retryable: false, status: "failed" };
@@ -505,6 +519,41 @@ class ProntoMessagesClient implements ProntoMessages {
         ? { status: "ambiguous" }
         : { retryable: data.retry_safe === true, status: "failed" };
     }
+  }
+
+  async resolveConversation(
+    input: Parameters<ProntoMessages["resolveConversation"]>[0],
+  ): Promise<ResolvedConversation | null> {
+    if (!safeProviderCoordinate(input.accountId) || !safeProviderCoordinate(input.conversationId)) {
+      return null;
+    }
+    const qualification = await this.qualify();
+    const chat = await this.#findExactChat({
+      accountId: input.accountId,
+      conversationId: input.conversationId,
+    });
+    if (chat === null || typeof chat.id !== "number") return null;
+    const history = record(await this.#rpc.request("messages.history", {
+      attachments: false,
+      chat_id: chat.id,
+      limit: 1,
+    }));
+    const messages = history.messages;
+    if (!Array.isArray(messages) || messages.length !== 1) return null;
+    const stats = await this.#rpc.request("messages.stats", { chat_id: chat.id });
+    const facts = normalizeConversationFacts(stats, chat.id, messages[0], chat);
+    if (
+      facts.routing?.accountId !== input.accountId ||
+      facts.routing.conversationId !== input.conversationId
+    ) return null;
+    return {
+      conversation: this.#scoped.issueConversation(
+        chat.id,
+        qualification.databaseGeneration,
+        facts,
+      ),
+      facts,
+    };
   }
 
   async #deliver(
@@ -532,7 +581,18 @@ class ProntoMessagesClient implements ProntoMessages {
       { chat_id: chatId },
       budget === undefined ? 30_000 : this.#providerTimeout(budget),
     ));
-    const event = normalizeEvent(rawMessage, normalizeConversationFacts(stats, chatId));
+    const conversationId = rawMessage.chat_guid;
+    const hasRoutingCandidate = safeProviderCoordinate(conversationId) &&
+      typeof rawMessage.is_group === "boolean" && Array.isArray(rawMessage.participants);
+    const chat = hasRoutingCandidate
+      ? await within(async () => await this.#findExactChat({
+          chatId,
+          conversationId,
+          timeoutMs: budget === undefined ? 30_000 : this.#providerTimeout(budget),
+        }))
+      : null;
+    const facts = normalizeConversationFacts(stats, chatId, rawMessage, chat);
+    const event = normalizeEvent(rawMessage, facts);
     if (event === null) return;
     const normalizedEvent: MessagesEvent = {
       ...event,
@@ -588,6 +648,31 @@ class ProntoMessagesClient implements ProntoMessages {
       }
       throw error;
     }
+  }
+
+  async #findExactChat(input: {
+    readonly accountId?: string;
+    readonly chatId?: number;
+    readonly conversationId: string;
+    readonly timeoutMs?: number;
+  }): Promise<Record<string, unknown> | null> {
+    for (const limit of CHAT_CATALOG_LIMITS) {
+      const response = record(await this.#rpc.request(
+        "chats.list",
+        { limit },
+        input.timeoutMs ?? 10_000,
+      ));
+      if (!Array.isArray(response.chats)) return null;
+      const matches = response.chats.map(record).filter((chat) =>
+        chat.guid === input.conversationId &&
+        (input.chatId === undefined || chat.id === input.chatId) &&
+        (input.accountId === undefined || chat.account_id === input.accountId)
+      );
+      if (matches.length > 1) return null;
+      if (matches.length === 1) return matches[0]!;
+      if (response.chats.length < limit) return null;
+    }
+    return null;
   }
 
   async #catchUp(

--- a/packages/messages/src/internal/normalize.ts
+++ b/packages/messages/src/internal/normalize.ts
@@ -78,15 +78,52 @@ function attachment(value: unknown): MessagesAttachment | null {
   };
 }
 
-export function normalizeConversationFacts(value: unknown, chatId: number): ConversationFacts {
+export function normalizeConversationFacts(
+  value: unknown,
+  chatId: number,
+  messageValue: unknown,
+  chatValue: unknown,
+): ConversationFacts {
   const result = record(value);
-  const chat = (Array.isArray(result.chats) ? result.chats : [])
+  const statsChat = (Array.isArray(result.chats) ? result.chats : [])
     .map(record)
     .find((candidate) => candidate.chat_id === chatId);
-  return {
+  const message = record(messageValue);
+  const chat = record(chatValue);
+  const accountId = optionalString(chat.account_id);
+  const accountLogin = optionalString(chat.account_login);
+  const conversationId = optionalString(chat.guid);
+  const destinationHandle = optionalString(chat.last_addressed_handle);
+  const participants = Array.isArray(message.participants) &&
+      message.participants.every((value) => typeof value === "string" && value !== "")
+    ? [...new Set(message.participants)] as string[]
+    : null;
+  const service = statsChat !== undefined
+    ? optionalString(statsChat.service)
+    : optionalString(chat.service);
+  const base: ConversationFacts = {
     ownerParticipated:
       typeof result.sent_messages === "number" && result.sent_messages > 0,
-    service: chat !== undefined ? optionalString(chat.service) : null,
+    service,
+  };
+  if (
+    accountId === null || accountLogin === null || conversationId === null ||
+    destinationHandle === null || chat.id !== chatId ||
+    message.chat_id !== chatId || message.chat_guid !== conversationId ||
+    typeof message.is_group !== "boolean" || chat.is_group !== message.is_group ||
+    participants === null || (message.is_group && participants.length === 0)
+  ) return base;
+  return {
+    ...base,
+    routing: {
+      accountId,
+      accountLogin,
+      conversationId,
+      destinationHandle,
+      isGroup: message.is_group,
+      label: optionalString(message.chat_name),
+      participants,
+    },
   };
 }
 

--- a/packages/messages/src/types.ts
+++ b/packages/messages/src/types.ts
@@ -15,7 +15,21 @@ export interface AttachmentReference {
 
 export interface ConversationFacts {
   readonly ownerParticipated: boolean;
+  readonly routing?: {
+    readonly accountId: string;
+    readonly accountLogin: string;
+    readonly conversationId: string;
+    readonly destinationHandle: string;
+    readonly isGroup: boolean;
+    readonly label: string | null;
+    readonly participants: readonly string[];
+  };
   readonly service: string | null;
+}
+
+export interface ResolvedConversation {
+  readonly conversation: ConversationReference;
+  readonly facts: ConversationFacts;
 }
 
 export interface MessagesAttachment {
@@ -171,8 +185,13 @@ export interface ProntoMessages {
   qualify(): Promise<MessagesQualification>;
   reply(input: {
     readonly conversation: ConversationReference;
+    readonly filePath?: string;
     readonly text: string;
   }): Promise<DeliveryOutcome>;
+  resolveConversation(input: {
+    readonly accountId: string;
+    readonly conversationId: string;
+  }): Promise<ResolvedConversation | null>;
   subscribe(input: {
     readonly onEvent: (event: MessagesEvent) => void | Promise<void>;
     readonly onOverflow?: (resumeAfterRowId: number) => void | Promise<void>;

--- a/packages/messages/test/public-interface.test.ts
+++ b/packages/messages/test/public-interface.test.ts
@@ -14,6 +14,7 @@ afterEach(async () => {
 
 interface TranscriptScenario {
   readonly event: Record<string, unknown>;
+  readonly expectedFilePath?: string;
   readonly exitDuringSend?: boolean;
   readonly nearby?: readonly Record<string, unknown>[];
   readonly sentMessages: number;
@@ -48,6 +49,20 @@ for await (const chunk of Bun.stdin.stream()) {
       };
     } else if (request.method === "watch.subscribe") {
       result = { subscription: 7 };
+    } else if (request.method === "chats.list") {
+      result = {
+        chats: [{
+          account_id: "E:owner@example.com",
+          account_login: "owner@example.com",
+          guid: "iMessage;-;+15550000000",
+          id: 42,
+          is_group: false,
+          last_addressed_handle: "+15551111111",
+          service: "iMessage",
+        }],
+      };
+    } else if (request.method === "messages.history") {
+      result = { messages: [scenario.event] };
     } else if (request.method === "messages.stats") {
       result = {
         chats: [{ chat_id: 42, service: "iMessage" }],
@@ -57,6 +72,10 @@ for await (const chunk of Bun.stdin.stream()) {
       result = { messages: scenario.nearby ?? [] };
     } else if (request.method === "send") {
       if (request.params.chat_id !== 42) throw new Error("reply was not exactly routed");
+      if (scenario.expectedFilePath !== undefined &&
+          request.params.file !== scenario.expectedFilePath) {
+        throw new Error("reply attachment was not preserved");
+      }
       if (scenario.exitDuringSend === true) process.exit(0);
       result = { ok: true, guid: "outbound-guid" };
     } else {
@@ -94,6 +113,9 @@ const inboundEvent = {
   guid: "inbound-guid",
   id: 101,
   is_from_me: false,
+  is_group: false,
+  chat_guid: "iMessage;-;+15550000000",
+  participants: ["+15550000000", "+15551111111"],
   sender: "+15550000000",
   service: "iMessage",
   text: "hello from Messages",
@@ -113,7 +135,19 @@ test("normalizes one inbound transcript event and replies to its exact conversat
       token: expect.any(String),
       version: 1,
     },
-    conversationFacts: { ownerParticipated: true, service: "iMessage" },
+    conversationFacts: {
+      ownerParticipated: true,
+      routing: {
+        accountId: "E:owner@example.com",
+        accountLogin: "owner@example.com",
+        conversationId: "iMessage;-;+15550000000",
+        destinationHandle: "+15551111111",
+        isGroup: false,
+        label: null,
+        participants: ["+15550000000", "+15551111111"],
+      },
+      service: "iMessage",
+    },
     message: {
       attachments: [],
       fromMe: false,
@@ -137,6 +171,38 @@ test("normalizes one inbound transcript event and replies to its exact conversat
     providerMessageId: "outbound-guid",
     status: "confirmed",
   });
+  await messages.close();
+});
+
+test("resolves one exact known conversation and preserves one outbound attachment", async () => {
+  const filePath = "/private/tmp/staged-report.pdf";
+  const messages = await transcriptClient({
+    event: inboundEvent,
+    expectedFilePath: filePath,
+    sentMessages: 3,
+  });
+  const resolved = await messages.resolveConversation({
+    accountId: "E:owner@example.com",
+    conversationId: "iMessage;-;+15550000000",
+  });
+  expect(resolved?.facts.routing).toMatchObject({
+    accountId: "E:owner@example.com",
+    conversationId: "iMessage;-;+15550000000",
+  });
+  expect(await messages.reply({
+    conversation: resolved!.conversation,
+    filePath,
+    text: "report attached",
+  })).toEqual({ providerMessageId: "outbound-guid", status: "confirmed" });
+  expect(await messages.reply({
+    conversation: resolved!.conversation,
+    filePath: "relative/report.pdf",
+    text: "unsafe path",
+  })).toEqual({ retryable: false, status: "failed" });
+  expect(await messages.resolveConversation({
+    accountId: "E:other@example.com",
+    conversationId: "iMessage;-;+15550000000",
+  })).toBeNull();
   await messages.close();
 });
 

--- a/packages/messages/test/public-interface.test.ts
+++ b/packages/messages/test/public-interface.test.ts
@@ -17,6 +17,7 @@ interface TranscriptScenario {
   readonly expectedFilePath?: string;
   readonly exitDuringSend?: boolean;
   readonly nearby?: readonly Record<string, unknown>[];
+  readonly replaceDatabaseDuringHistory?: boolean;
   readonly sentMessages: number;
 }
 
@@ -62,6 +63,12 @@ for await (const chunk of Bun.stdin.stream()) {
         }],
       };
     } else if (request.method === "messages.history") {
+      if (scenario.replaceDatabaseDuringHistory === true) {
+        const replacement = scenario.databasePath + ".replacement";
+        await Bun.write(replacement, "replacement database evidence");
+        await import("node:fs/promises").then(({ rename }) =>
+          rename(replacement, scenario.databasePath));
+      }
       result = { messages: [scenario.event] };
     } else if (request.method === "messages.stats") {
       result = {
@@ -201,6 +208,19 @@ test("resolves one exact known conversation and preserves one outbound attachmen
   })).toEqual({ retryable: false, status: "failed" });
   expect(await messages.resolveConversation({
     accountId: "E:other@example.com",
+    conversationId: "iMessage;-;+15550000000",
+  })).toBeNull();
+  await messages.close();
+});
+
+test("does not issue a conversation reference across database generations", async () => {
+  const messages = await transcriptClient({
+    event: inboundEvent,
+    replaceDatabaseDuringHistory: true,
+    sentMessages: 3,
+  });
+  expect(await messages.resolveConversation({
+    accountId: "E:owner@example.com",
     conversationId: "iMessage;-;+15550000000",
   })).toBeNull();
   await messages.close();

--- a/packages/messages/test/recovery.test.ts
+++ b/packages/messages/test/recovery.test.ts
@@ -585,6 +585,84 @@ ${rpcLoop(`
   await messages.close();
 }, 5_000);
 
+test("does not publish enriched routing facts across database generations", async () => {
+  const directory = await fixtureDirectory();
+  const databasePath = join(directory, "chat.db");
+  await writeFile(databasePath, "first database evidence");
+  const occurredAt = new Date().toISOString();
+  const executable = await executableWithSource(directory, `
+import { renameSync, writeFileSync } from "node:fs";
+let subscriptions = 0;
+let replaced = false;
+${rpcLoop(`
+    let result;
+    if (request.method === "initialize") result = {
+      protocol_version: 1,
+      version: "0.14.1",
+      database: { path: ${JSON.stringify(databasePath)}, ready: true, features: { routing_metadata: true } },
+      methods: ["initialize", "status", "chats.list", "messages.history", "messages.after", "messages.stats", "watch.subscribe", "watch.unsubscribe", "send"],
+    };
+    else if (request.method === "watch.subscribe") {
+      subscriptions += 1;
+      result = { subscription: subscriptions };
+    } else if (request.method === "messages.stats") {
+      result = { chats: [{ chat_id: 42, service: "RCS" }], sent_messages: 1 };
+    } else if (request.method === "chats.list") {
+      if (!replaced) {
+        replaced = true;
+        writeFileSync(${JSON.stringify(databasePath)} + ".replacement", "second database evidence");
+        renameSync(${JSON.stringify(databasePath)} + ".replacement", ${JSON.stringify(databasePath)});
+      }
+      result = { chats: [{
+        account_id: "E:owner@example.com",
+        account_login: "owner@example.com",
+        guid: "RCS;-;+15550000000",
+        id: 42,
+        is_group: false,
+        last_addressed_handle: "+15551111111",
+        service: "RCS",
+      }] };
+    } else result = { ok: true };
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: request.id, result }) + "\\n");
+    if (request.method === "watch.subscribe" && subscriptions === 1) {
+      process.stdout.write(JSON.stringify({ jsonrpc: "2.0", method: "message", params: {
+        subscription: 1,
+        message: {
+          chat_id: 42,
+          chat_guid: "RCS;-;+15550000000",
+          created_at: ${JSON.stringify(occurredAt)},
+          guid: "old-generation-guid",
+          id: 1,
+          is_from_me: false,
+          is_group: false,
+          participants: ["+15550000000", "+15551111111"],
+          sender: "+15550000000",
+          service: "RCS",
+          text: "must not escape",
+        },
+      } }) + "\\n");
+    }
+  `)}
+  `);
+  const messages = createProntoMessages({ imsgPath: executable });
+  const deliveredRowIds: number[] = [];
+  const outcomes: MessagesRecoveryOutcome[] = [];
+  const subscription = await messages.subscribe({
+    onEvent: (event) => { deliveredRowIds.push(event.message.rowId); },
+    onRecovery: (outcome) => { outcomes.push(outcome); },
+  });
+  const deadline = Date.now() + 3_000;
+  while (outcomes.length < 1 && Date.now() < deadline) await Bun.sleep(20);
+
+  expect(deliveredRowIds).toEqual([]);
+  expect(outcomes).toContainEqual(expect.objectContaining({
+    reason: "database-generation-changed",
+    status: "degraded",
+  }));
+  await subscription.close();
+  await messages.close();
+}, 5_000);
+
 test("discards an old-watch notification after observing a new database generation", async () => {
   const directory = await fixtureDirectory();
   const databasePath = join(directory, "chat.db");

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -28,7 +28,7 @@ describe("Pronto CLI", () => {
     ]);
 
     expect(exitCode).toBe(0);
-    expect(stdout.trim()).toBe("pronto 0.1.0");
+    expect(stdout.trim()).toBe("pronto 0.2.0");
   });
 
   test("the legacy command explains the rename and delegates safe commands", async () => {
@@ -46,7 +46,7 @@ describe("Pronto CLI", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr.trim()).toBe("s4imsg is now Pronto; use the pronto command.");
-    expect(stdout.trim()).toBe("pronto 0.1.0");
+    expect(stdout.trim()).toBe("pronto 0.2.0");
   });
 
   test("the legacy command refuses to start a second foreground listener", async () => {

--- a/test/unit/current-chat-source.test.ts
+++ b/test/unit/current-chat-source.test.ts
@@ -79,6 +79,7 @@ test("queries details, rich history, and materialized attachments through public
       status: "ready",
     }),
     reply: async () => ({ providerMessageId: "reply", status: "confirmed" }),
+    resolveConversation: async () => null,
     subscribe: async () => ({
       close: async () => undefined,
       terminated: new Promise<void>(() => undefined),

--- a/test/unit/imsg-transport.test.ts
+++ b/test/unit/imsg-transport.test.ts
@@ -83,6 +83,9 @@ class FakeMessages implements ProntoMessages {
     this.replyInput = input;
     return this.replyOutcome;
   }
+  async resolveConversation(): ReturnType<ProntoMessages["resolveConversation"]> {
+    return null;
+  }
   async subscribe(
     input: Parameters<ProntoMessages["subscribe"]>[0],
   ): Promise<MessagesSubscription> {


### PR DESCRIPTION
## Summary

- expose exact, bounded account-and-conversation resolution for package consumers
- enrich eligible events with verified routing facts while preserving the safe legacy floor
- support one consumer-staged outbound file with explicit delivery semantics
- fail closed across Messages database generation changes
- document the clean-room provenance and accepted attachment boundary

## Verification

- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun test` (225 pass)
- `bun run build`
- `bun run release:validate`

The v0.2.0 remote canary remains intentionally pending until this exact candidate is installed.