### PR TITLE
Allow npm processing to settle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
             npm publish "./release-assets/$PACKAGE_FILE" --provenance --access public
           fi
           REMOTE_VERSION=""
-          for ATTEMPT in {1..12}; do
+          for ATTEMPT in {1..60}; do
             REMOTE_VERSION="$(npm view "pronto-imessage@$PACKAGE_VERSION" version 2>/dev/null || true)"
             [[ "$REMOTE_VERSION" = "$PACKAGE_VERSION" ]] && break
             sleep 5

--- a/scripts/release-workflow-validation.ts
+++ b/scripts/release-workflow-validation.ts
@@ -5,7 +5,7 @@ const REQUIRED_CONTROLS = [
   ],
   ["NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}", "npm authentication"],
   ["id-token: write", "OIDC provenance permission"],
-  ["for ATTEMPT in {1..12}; do", "npm registry propagation retry"],
+  ["for ATTEMPT in {1..60}; do", "npm registry propagation retry"],
   ["dist/pronto-imessage-*.tgz", "package release artifact"],
   ["sha256sum -c pronto-imessage.sha256", "downloaded package checksum verification"],
   ["workflow_dispatch:", "manual immutable-tag recovery"],

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -42,7 +42,7 @@ describe("release workflow", () => {
   test("retries npm verification while a new version propagates", async () => {
     const workflow = await releaseWorkflow();
 
-    expect(workflow).toContain("for ATTEMPT in {1..12}; do");
+    expect(workflow).toContain("for ATTEMPT in {1..60}; do");
     expect(workflow).toContain('REMOTE_VERSION="$(npm view "pronto-imessage@$PACKAGE_VERSION" version 2>/dev/null || true)"');
     expect(workflow).toContain('[[ "$REMOTE_VERSION" = "$PACKAGE_VERSION" ]] && break');
     expect(workflow).toContain("sleep 5");
@@ -60,7 +60,7 @@ describe("release workflow", () => {
       'npm publish "./release-assets/$PACKAGE_FILE" --provenance --access public',
       "NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}",
       "id-token: write",
-      "for ATTEMPT in {1..12}; do",
+      "for ATTEMPT in {1..60}; do",
       "dist/pronto-imessage-*.tgz",
       "sha256sum -c pronto-imessage.sha256",
       "workflow_dispatch:",


### PR DESCRIPTION
## Summary

Extend post-publish registry verification from one minute to five minutes. npm accepted and signed v0.2.0 immediately but needed slightly longer than the previous window to expose it through registry reads.

The immutable release recovery path completed v0.2.0 safely; this change prevents the same harmless processing delay from leaving future releases in draft.

## Verification

- `bun test test/unit/release-workflow.test.ts`
- `bun run release:validate`