### PR TITLE
feat(messages): adopt verified provider checkpoints

### DIFF
--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -20,3 +20,10 @@ consumer-staged outbound file. It was independently implemented in this public
 repository and verified with synthetic public transcript and fault fixtures.
 No private consumer imports, source history, fixtures, identifiers, or domain
 models were used.
+
+The versioned checkpoint-adoption seam added for `pronto-imessage` 0.2.1 was
+cleanly derived from the predecessor consumer's generation-bound cursor format.
+Only the generic database identity canonicalization was retained. Adoption
+requires the caller's pre-cutover provider-message witness and is covered by
+public replacement/rebuild rejection tests; no consumer code or private history
+was copied.

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "pronto-cli",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "bin": {
         "pronto": "./src/cli.ts",
         "s4imsg": "./src/legacy-cli.ts",
@@ -23,7 +23,7 @@
     },
     "packages/messages": {
       "name": "pronto-imessage",
-      "version": "0.2.0",
+      "version": "0.2.1",
     },
   },
   "packages": {

--- a/docs/RELEASE_QUALIFICATION.md
+++ b/docs/RELEASE_QUALIFICATION.md
@@ -17,7 +17,7 @@ file records capability evidence, not private conversation data.
 | Claude effective local probe | 2.1.226 | Setup noninteractive file-tool probe | Pass |
 | Messages Automation | Owner test chats, 2026-09-02 | Exactly one self-chat send and one RCS send; expected self-chat display mirror only | Pass |
 | Self-chat mirror handling | Owner self-chat, 2026-09-02 | One tagged activation and one agent send with no echo turn | Pass |
-| Full remote tagged flow | v0.2.0 | Owner RCS chat, 2026-09-02: exact re-resolution, one tagged activation, one confirmed reply, no echo turn | Pass |
+| Full remote tagged flow | v0.2.1 | Owner RCS chat, 2026-09-02: exact candidate installed with one listener, one tagged activation, one confirmed reply, no retry or echo turn | Pass |
 
 The automated matrix and owner smoke record versions tested on 2026-09-02.
 Capability checks, not version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-workspace",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A local iMessage bridge for Codex and Claude Code",
   "type": "module",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/messages/README.md
+++ b/packages/messages/README.md
@@ -41,6 +41,13 @@ const subscription = await messages.subscribe({
 });
 ```
 
+A consumer migrating an older provider checkpoint can call `adoptCheckpoint`
+after qualification and before subscribing. The versioned candidate includes
+the prior database generation, row, and provider message ID. Pronto accepts it
+only when the database identity matches and that exact pre-cutover witness is
+still present; otherwise it returns a structured rejection. An existing Pronto
+checkpoint is always preserved.
+
 The package binds durable checkpoints to a fingerprint of the current Messages database. It restarts and resubscribes after provider failure, performs catch-up within row-count, age, and wall-clock limits, and reports privacy-safe recovery diagnostics. A send that may have reached the provider is returned as `ambiguous` and is never automatically replayed.
 
 Every observed conversation carries a module-issued, versioned, tamper-evident reference with an expiry. References are process-local by default. A consumer with durable queued work can provide a stable owner-private `referenceKey` of at least 32 bytes; that permits an unexpired observed reference to be revalidated after restart without granting access to a different chat. Rotating the key invalidates outstanding references. History requires that exact reference plus an explicit message, row, byte, and RPC-call budget. Pagination continuations remain bound to the same conversation capability and database generation. They cannot be used to search another conversation.

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-imessage",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Reusable local Apple Messages transport for Pronto consumers",
   "type": "module",
   "license": "MIT",

--- a/packages/messages/src/index.ts
+++ b/packages/messages/src/index.ts
@@ -13,7 +13,10 @@ import {
   qualify,
   record,
 } from "./internal/normalize.js";
-import { databaseGeneration } from "./internal/generation.js";
+import {
+  databaseGeneration,
+  legacyDatabaseGeneration,
+} from "./internal/generation.js";
 import {
   ConversationReferenceExpiredError,
   ScopedMessagesAccess,
@@ -29,6 +32,8 @@ import type {
   CreateProntoMessagesOptions,
   MaterializedAttachment,
   MessagesDiagnostics,
+  MessagesCheckpointAdoptionOutcome,
+  MessagesCheckpointCandidate,
   MessagesEvent,
   MessagesHistoryPage,
   MessagesQualification,
@@ -50,6 +55,8 @@ export type {
   MessagesHistoryBudget,
   MessagesHistoryPage,
   MessagesDiagnostics,
+  MessagesCheckpointAdoptionOutcome,
+  MessagesCheckpointCandidate,
   MessagesQualification,
   MessagesRecoveryOutcome,
   MessagesRecoveryLimits,
@@ -174,6 +181,61 @@ class ProntoMessagesClient implements ProntoMessages {
       state: this.#closed ? "closed" : rpc.state === "recovering" ? "recovering" : this.#diagnostics.state,
       ...(rpc.nextRetryAt === undefined ? {} : { nextRetryAt: rpc.nextRetryAt }),
     };
+  }
+
+  async adoptCheckpoint(
+    input: Parameters<NonNullable<ProntoMessages["adoptCheckpoint"]>>[0],
+  ): Promise<MessagesCheckpointAdoptionOutcome> {
+    if (this.#closed) throw new Error("messages_closed");
+    if (this.#subscriptionActive) throw new Error("messages_checkpoint_adoption_too_late");
+    if (input.version !== 1 || input.databaseGeneration.trim() === "" ||
+        !Number.isSafeInteger(input.rowId) || input.rowId < 0 ||
+        (input.rowId === 0 && input.providerMessageId !== undefined) ||
+        (input.rowId > 0 && !safeProviderCoordinate(input.providerMessageId))) {
+      throw new Error("messages_checkpoint_invalid");
+    }
+    if (await this.#state.currentCheckpoint() !== undefined) return { status: "preserved" };
+    const qualification = await this.qualify();
+    const path = this.#databasePath;
+    if (path === undefined) throw new Error("messages_database_generation_unavailable");
+    const compatible = input.databaseGeneration === qualification.databaseGeneration ||
+      input.databaseGeneration === await legacyDatabaseGeneration(path);
+    if (!compatible) {
+      return { reason: "database-generation-mismatch", status: "rejected" };
+    }
+    let witness: { readonly providerMessageDigest: string; readonly rowId: number } | undefined;
+    if (input.rowId > 0) {
+      const providerMessageId = input.providerMessageId;
+      if (providerMessageId === undefined) throw new Error("messages_checkpoint_invalid");
+      const page = record(await this.#rpc.request("messages.after", {
+        attachments: false,
+        include_reactions: true,
+        limit: 1,
+        since_rowid: Math.max(0, input.rowId - 1),
+      }));
+      if (!Array.isArray(page.messages)) {
+        throw new Error("imsg returned invalid checkpoint evidence");
+      }
+      const raw = page.messages.find((value) => record(value).id === input.rowId);
+      const message = record(raw);
+      if (message.guid !== providerMessageId) {
+        return { reason: "checkpoint-witness-unavailable", status: "rejected" };
+      }
+      witness = {
+        providerMessageDigest: this.#providerMessageDigest(providerMessageId),
+        rowId: input.rowId,
+      };
+    }
+    if (await this.#refreshGeneration() !== qualification.databaseGeneration) {
+      return { reason: "database-generation-mismatch", status: "rejected" };
+    }
+    return await this.#state.initialize(
+        qualification.databaseGeneration,
+        input.rowId,
+        witness,
+      )
+      ? { status: "adopted" }
+      : { status: "preserved" };
   }
 
   async history(
@@ -860,6 +922,7 @@ class ProntoMessagesClient implements ProntoMessages {
   }
 
   async #checkpointWitnessMatches(checkpoint: ProviderCheckpoint): Promise<boolean> {
+    if (checkpoint.rowId === 0) return true;
     if (checkpoint.witnesses === undefined || checkpoint.witnesses.length === 0) return false;
     const highWatermark = record(await this.#rpc.request("messages.after", {
       attachments: false,

--- a/packages/messages/src/internal/generation.ts
+++ b/packages/messages/src/internal/generation.ts
@@ -2,12 +2,42 @@ import { createHash } from "node:crypto";
 import { realpath, stat } from "node:fs/promises";
 
 export async function databaseGeneration(path: string): Promise<string> {
+  const identity = await databaseIdentity(path);
+  return digest({
+    birthtimeMs: identity.birthtimeMs,
+    device: identity.device,
+    inode: identity.inode,
+    path: identity.path,
+  });
+}
+
+/** Compatibility identity for checkpoints produced by the predecessor canonicalization. */
+export async function legacyDatabaseGeneration(path: string): Promise<string> {
+  const identity = await databaseIdentity(path);
+  return digest({
+    path: identity.path,
+    device: identity.device,
+    inode: identity.inode,
+    birthtime: identity.birthtimeMs,
+  });
+}
+
+async function databaseIdentity(path: string): Promise<{
+  readonly birthtimeMs: number;
+  readonly device: string;
+  readonly inode: string;
+  readonly path: string;
+}> {
   const [resolved, metadata] = await Promise.all([realpath(path), stat(path)]);
   if (!metadata.isFile()) throw new Error("messages_database_generation_unavailable");
-  return createHash("sha256").update(JSON.stringify({
+  return {
     birthtimeMs: metadata.birthtimeMs,
     device: String(metadata.dev),
     inode: String(metadata.ino),
     path: resolved,
-  })).digest("base64url");
+  };
+}
+
+function digest(value: Readonly<Record<string, string | number>>): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("base64url");
 }

--- a/packages/messages/src/internal/state.ts
+++ b/packages/messages/src/internal/state.ts
@@ -33,6 +33,11 @@ export interface CheckpointStore {
   ): Promise<void>;
   checkpoint(databaseGeneration: string): Promise<ProviderCheckpoint | undefined>;
   currentCheckpoint(): Promise<ProviderCheckpoint | undefined>;
+  initialize(
+    databaseGeneration: string,
+    rowId: number,
+    witness?: ProviderCheckpointWitness,
+  ): Promise<boolean>;
 }
 
 interface ProviderStateV2 {
@@ -125,6 +130,25 @@ export class ProviderStateStore implements CheckpointStore {
     });
   }
 
+  initialize(
+    databaseGeneration: string,
+    rowId: number,
+    witness?: ProviderCheckpointWitness,
+  ): Promise<boolean> {
+    return this.#serialized(async () => {
+      const state = await this.#load();
+      if (state.checkpoint !== null) return false;
+      await this.#save({
+        checkpoint: nextCheckpoint(undefined, databaseGeneration, rowId, witness),
+        ...(state.legacyUnscopedCursor === undefined
+          ? {}
+          : { legacyUnscopedCursor: state.legacyUnscopedCursor }),
+        version: 2,
+      });
+      return true;
+    });
+  }
+
   async #load(): Promise<ProviderStateV2> {
     await mkdir(dirname(this.#path), { mode: 0o700, recursive: true });
     let source: string;
@@ -213,6 +237,16 @@ export class MemoryCheckpointStore implements CheckpointStore {
 
   async currentCheckpoint(): Promise<ProviderCheckpoint | undefined> {
     return this.#checkpoint;
+  }
+
+  async initialize(
+    databaseGeneration: string,
+    rowId: number,
+    witness?: ProviderCheckpointWitness,
+  ): Promise<boolean> {
+    if (this.#checkpoint !== undefined) return false;
+    this.#checkpoint = nextCheckpoint(undefined, databaseGeneration, rowId, witness);
+    return true;
   }
 
   async advance(

--- a/packages/messages/src/types.ts
+++ b/packages/messages/src/types.ts
@@ -80,6 +80,20 @@ export interface MessagesQualification {
   readonly status: "ready";
 }
 
+export type MessagesCheckpointAdoptionOutcome =
+  | { readonly status: "adopted" | "preserved" }
+  | {
+      readonly reason: "database-generation-mismatch" | "checkpoint-witness-unavailable";
+      readonly status: "rejected";
+    };
+
+export interface MessagesCheckpointCandidate {
+  readonly databaseGeneration: string;
+  readonly providerMessageId?: string;
+  readonly rowId: number;
+  readonly version: 1;
+}
+
 export type MessagesRecoveryReason =
   | "age-limit"
   | "database-generation-changed"
@@ -168,6 +182,7 @@ export interface MessagesSubscription {
 }
 
 export interface ProntoMessages {
+  adoptCheckpoint?(input: MessagesCheckpointCandidate): Promise<MessagesCheckpointAdoptionOutcome>;
   close(): Promise<void>;
   diagnostics(): MessagesDiagnostics;
   history(input: {

--- a/packages/messages/test/recovery.test.ts
+++ b/packages/messages/test/recovery.test.ts
@@ -106,6 +106,83 @@ test("reports bounded age recovery and resumes with live events only", async () 
   await messages.close();
 });
 
+test("adopts a verified checkpoint from a compatible legacy generation", async () => {
+  const directory = await fixtureDirectory();
+  const databasePath = join(directory, "chat.db");
+  const statePath = join(directory, "provider-state.json");
+  await writeFile(databasePath, "database evidence");
+  const metadata = await import("node:fs/promises").then(({ stat }) => stat(databasePath));
+  const resolved = await import("node:fs/promises").then(({ realpath }) => realpath(databasePath));
+  const legacyGeneration = createHash("sha256").update(JSON.stringify({
+    path: resolved,
+    device: String(metadata.dev),
+    inode: String(metadata.ino),
+    birthtime: metadata.birthtimeMs,
+  })).digest("base64url");
+  const executable = await executableWithSource(directory, rpcLoop(`
+    let result;
+    if (request.method === "initialize") result = {
+      protocol_version: 1,
+      version: "0.14.1",
+      database: { path: ${JSON.stringify(databasePath)}, ready: true, features: { routing_metadata: true } },
+      methods: ["initialize", "status", "chats.list", "messages.history", "messages.after", "messages.stats", "watch.subscribe", "watch.unsubscribe", "send"],
+    };
+    else if (request.method === "messages.after" && request.params.since_rowid === 39) result = {
+      has_more: false,
+      messages: [{ guid: "checkpoint-guid", id: 40 }],
+      next_rowid: 40,
+    };
+    else result = { ok: true };
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: request.id, result }) + "\\n");
+  `));
+  const messages = createProntoMessages({ imsgPath: executable, statePath });
+
+  await expect(messages.adoptCheckpoint!({
+    databaseGeneration: legacyGeneration,
+    providerMessageId: "checkpoint-guid",
+    rowId: 40,
+    version: 1,
+  })).resolves.toEqual({ status: "adopted" });
+  await expect(messages.adoptCheckpoint!({
+    databaseGeneration: legacyGeneration,
+    providerMessageId: "newer-guid",
+    rowId: 41,
+    version: 1,
+  })).resolves.toEqual({ status: "preserved" });
+  expect(await new ProviderStateStore(statePath).checkpoint(
+    await databaseGeneration(databasePath),
+  )).toMatchObject({ rowId: 40 });
+  await messages.close();
+
+  const rejectedStatePath = join(directory, "rejected-provider-state.json");
+  const rejected = createProntoMessages({ imsgPath: executable, statePath: rejectedStatePath });
+  await expect(rejected.adoptCheckpoint!({
+    databaseGeneration: "different-database-generation",
+    providerMessageId: "checkpoint-guid",
+    rowId: 40,
+    version: 1,
+  })).resolves.toEqual({
+    reason: "database-generation-mismatch",
+    status: "rejected",
+  });
+  expect(await new ProviderStateStore(rejectedStatePath).currentCheckpoint()).toBeUndefined();
+  await rejected.close();
+
+  const rebuiltStatePath = join(directory, "rebuilt-provider-state.json");
+  const rebuilt = createProntoMessages({ imsgPath: executable, statePath: rebuiltStatePath });
+  await expect(rebuilt.adoptCheckpoint!({
+    databaseGeneration: legacyGeneration,
+    providerMessageId: "guid-before-in-place-rebuild",
+    rowId: 40,
+    version: 1,
+  })).resolves.toEqual({
+    reason: "checkpoint-witness-unavailable",
+    status: "rejected",
+  });
+  expect(await new ProviderStateStore(rebuiltStatePath).currentCheckpoint()).toBeUndefined();
+  await rebuilt.close();
+});
+
 test("enforces row-count and wall-clock recovery bounds", async () => {
   const runBoundedRecovery = async (input: {
     readonly delayMs: number;

--- a/packages/messages/test/state.test.ts
+++ b/packages/messages/test/state.test.ts
@@ -73,6 +73,26 @@ test("advances only within one proven generation and never reuses a replaced gen
   expect(await store.checkpoint("generation-one")).toBeUndefined();
 });
 
+test("initializes a generation-bound checkpoint exactly once", async () => {
+  const path = await statePath();
+  const store = new ProviderStateStore(path);
+
+  expect(await store.initialize("generation-one", 40, {
+    providerMessageDigest: "digest-40",
+    rowId: 40,
+  })).toBe(true);
+  expect(await store.initialize("generation-one", 41, {
+    providerMessageDigest: "digest-41",
+    rowId: 41,
+  })).toBe(false);
+  expect(await store.currentCheckpoint()).toEqual({
+    databaseGeneration: "generation-one",
+    rowId: 40,
+    version: 1,
+    witnesses: [{ providerMessageDigest: "digest-40", rowId: 40 }],
+  });
+});
+
 test("retains a bounded set of recent checkpoint witnesses", async () => {
   const path = await statePath();
   const store = new ProviderStateStore(path);

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -28,7 +28,7 @@ describe("Pronto CLI", () => {
     ]);
 
     expect(exitCode).toBe(0);
-    expect(stdout.trim()).toBe("pronto 0.2.0");
+    expect(stdout.trim()).toBe("pronto 0.2.1");
   });
 
   test("the legacy command explains the rename and delegates safe commands", async () => {
@@ -46,7 +46,7 @@ describe("Pronto CLI", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr.trim()).toBe("s4imsg is now Pronto; use the pronto command.");
-    expect(stdout.trim()).toBe("pronto 0.2.0");
+    expect(stdout.trim()).toBe("pronto 0.2.1");
   });
 
   test("the legacy command refuses to start a second foreground listener", async () => {


### PR DESCRIPTION
## Summary
- add a versioned, witnessed checkpoint-adoption API for safe host migrations
- reject database replacements, in-place rebuilds, and unwitnessed checkpoints
- qualify the exact v0.2.1 candidate with a one-listener RCS canary

## Verification
- `bun run typecheck`
- `bun test` (227 passing)
- `bun run build`
- `bun run release:validate`
- independent standards and correctness reviews: clean
- live RCS canary: one activation, one confirmed reply, no retry or echo