### PR TITLE
Publish npm package with trusted OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,6 @@ jobs:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
       IS_PRERELEASE: ${{ needs.build.outputs.prerelease }}
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       PACKAGE_FILE: ${{ needs.build.outputs.package-file }}
       PACKAGE_VERSION: ${{ needs.build.outputs.package-version }}
       RELEASE_TAG: ${{ needs.build.outputs.release-tag }}
@@ -124,6 +123,12 @@ jobs:
         with:
           node-version: 22.23.1
           registry-url: https://registry.npmjs.org
+      - name: Install npm with trusted-publishing support
+        run: npm install --global npm@11.19.1
+      - name: Verify trusted-publishing prerequisites
+        run: |
+          test "$(node --version)" = "v22.23.1"
+          test "$(npm --version)" = "11.19.1"
       - name: Verify downloaded checksum
         working-directory: release-assets
         run: |

--- a/scripts/release-workflow-validation.ts
+++ b/scripts/release-workflow-validation.ts
@@ -3,8 +3,9 @@ const REQUIRED_CONTROLS = [
     'npm publish "./release-assets/$PACKAGE_FILE" --provenance --access public',
     "npm publication with provenance",
   ],
-  ["NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}", "npm authentication"],
-  ["id-token: write", "OIDC provenance permission"],
+  ["id-token: write", "OIDC publishing permission"],
+  ["npm install --global npm@11.19.1", "trusted-publishing npm CLI"],
+  ['test "$(npm --version)" = "11.19.1"', "trusted-publishing npm CLI verification"],
   ["for ATTEMPT in {1..60}; do", "npm registry propagation retry"],
   ["dist/pronto-imessage-*.tgz", "package release artifact"],
   ["sha256sum -c pronto-imessage.sha256", "downloaded package checksum verification"],
@@ -50,6 +51,9 @@ export function releaseWorkflowViolations(workflow: string): string[] {
   const npmPublish = workflow.indexOf("npm publish");
   if (npmPublish >= 0 && (publishJob < 0 || npmPublish <= publishJob)) {
     violations.push("npm publication must run only in the dependent publish job");
+  }
+  if (/NODE_AUTH_TOKEN|secrets\.NPM_TOKEN/.test(workflow)) {
+    violations.push("release workflow must use OIDC instead of an npm token");
   }
   return violations;
 }

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -58,8 +58,9 @@ describe("release workflow", () => {
     const workflow = await releaseWorkflow();
     for (const control of [
       'npm publish "./release-assets/$PACKAGE_FILE" --provenance --access public',
-      "NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}",
       "id-token: write",
+      "npm install --global npm@11.19.1",
+      'test "$(npm --version)" = "11.19.1"',
       "for ATTEMPT in {1..60}; do",
       "dist/pronto-imessage-*.tgz",
       "sha256sum -c pronto-imessage.sha256",
@@ -70,6 +71,8 @@ describe("release workflow", () => {
       expect(releaseWorkflowViolations(workflow.replace(control, "removed-control")))
         .not.toEqual([]);
     }
+    expect(releaseWorkflowViolations(`${workflow}\nNODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}`))
+      .toContain("release workflow must use OIDC instead of an npm token");
     const reordered = workflow
       .replace("- name: Publish and verify pronto-imessage", "- name: temporary-step")
       .replace("- name: Create draft release", "- name: Publish and verify pronto-imessage")


### PR DESCRIPTION
## Summary
- publish `pronto-imessage` through npm trusted publishing instead of a long-lived token
- pin npm 11.19.1 and verify the required CLI version before publishing
- update release validation so token authentication cannot return unnoticed

## Verification
- `bun test test/unit/release-workflow.test.ts`
- `bun run build`
- `bun run release:validate`