### PR TITLE
Release Pronto v0.2.2 with launchd runtime PATH fix

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "pronto-cli",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "bin": {
         "pronto": "./src/cli.ts",
         "s4imsg": "./src/legacy-cli.ts",
@@ -23,7 +23,7 @@
     },
     "packages/messages": {
       "name": "pronto-imessage",
-      "version": "0.2.1",
+      "version": "0.2.2",
     },
   },
   "packages": {

--- a/docs/RELEASE_QUALIFICATION.md
+++ b/docs/RELEASE_QUALIFICATION.md
@@ -17,7 +17,7 @@ file records capability evidence, not private conversation data.
 | Claude effective local probe | 2.1.226 | Setup noninteractive file-tool probe | Pass |
 | Messages Automation | Owner test chats, 2026-09-02 | Exactly one self-chat send and one RCS send; expected self-chat display mirror only | Pass |
 | Self-chat mirror handling | Owner self-chat, 2026-09-02 | One tagged activation and one agent send with no echo turn | Pass |
-| Full remote tagged flow | v0.2.1 | Owner RCS chat, 2026-09-02: exact candidate installed with one listener, one tagged activation, one confirmed reply, no retry or echo turn | Pass |
+| Full remote tagged flow | v0.2.2 | Owner RCS chat, 2026-09-02: exact candidate installed with one listener, one tagged activation, one confirmed reply, no retry or echo turn after one minute | Pass |
 
 The automated matrix and owner smoke record versions tested on 2026-09-02.
 Capability checks, not version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-workspace",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A local iMessage bridge for Codex and Claude Code",
   "type": "module",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/macos/launch-agent.ts
+++ b/packages/cli/src/macos/launch-agent.ts
@@ -1,4 +1,5 @@
 import { unlink } from "node:fs/promises";
+import { dirname } from "node:path";
 import { atomicWritePrivate } from "../config";
 import { LAUNCH_AGENT_LABEL } from "./paths";
 
@@ -46,7 +47,15 @@ function xml(value: string): string {
 export function renderLaunchAgent(input: {
   executablePath: string;
   logPath: string;
+  runtimeExecutablePaths: readonly string[];
 }): string {
+  const runtimePath = [...new Set([
+    ...input.runtimeExecutablePaths.map((path) => dirname(path)),
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+  ])].join(":");
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -58,6 +67,11 @@ export function renderLaunchAgent(input: {
     <string>${xml(input.executablePath)}</string>
     <string>run</string>
   </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>${xml(runtimePath)}</string>
+  </dict>
   <key>RunAtLoad</key>
   <true/>
   <key>KeepAlive</key>

--- a/packages/cli/src/macos/setup.ts
+++ b/packages/cli/src/macos/setup.ts
@@ -657,6 +657,10 @@ export async function installSetup(input: {
       plist: renderLaunchAgent({
         executablePath: input.paths.executablePath,
         logPath: input.paths.logPath,
+        runtimeExecutablePaths: [
+          input.config.primaryRuntimePath,
+          input.config.fallbackRuntimePath,
+        ].filter((path): path is string => path !== undefined),
       }),
       plistPath: input.paths.launchAgentPath,
     });

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-imessage",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Reusable local Apple Messages transport for Pronto consumers",
   "type": "module",
   "license": "MIT",

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -28,7 +28,7 @@ describe("Pronto CLI", () => {
     ]);
 
     expect(exitCode).toBe(0);
-    expect(stdout.trim()).toBe("pronto 0.2.1");
+    expect(stdout.trim()).toBe("pronto 0.2.2");
   });
 
   test("the legacy command explains the rename and delegates safe commands", async () => {
@@ -46,7 +46,7 @@ describe("Pronto CLI", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr.trim()).toBe("s4imsg is now Pronto; use the pronto command.");
-    expect(stdout.trim()).toBe("pronto 0.2.1");
+    expect(stdout.trim()).toBe("pronto 0.2.2");
   });
 
   test("the legacy command refuses to start a second foreground listener", async () => {

--- a/test/unit/launch-agent.test.ts
+++ b/test/unit/launch-agent.test.ts
@@ -25,11 +25,19 @@ test("renders a stable owner LaunchAgent without shell interpolation", () => {
   const plist = renderLaunchAgent({
     executablePath: "/Users/me/Application Support/pronto/bin/pronto",
     logPath: "/Users/me/Logs/pronto/agent & output.log",
+    runtimeExecutablePaths: [
+      "/opt/homebrew/bin/codex",
+      "/Users/me/.local/bin/claude",
+      "/opt/homebrew/bin/codex",
+    ],
   });
 
   expect(plist).toContain("dev.pronto.agent");
   expect(plist).toContain("<string>run</string>");
   expect(plist).toContain("agent &amp; output.log");
+  expect(plist).toContain(
+    "<string>/opt/homebrew/bin:/Users/me/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>",
+  );
   expect(plist).not.toContain("/bin/sh");
 });
 


### PR DESCRIPTION
## Summary
- add configured runtime executable directories to the installed LaunchAgent PATH
- prevent script-based Codex and Claude runtimes from failing under launchd when their sibling Node binary is outside the system PATH
- bump Pronto and pronto-imessage to v0.2.2 and record exact-candidate RCS qualification

## Verification
- 
-    [6ms]  bundle  39 modules
  [98ms] compile  /private/tmp/pronto-v0.2.2-qualification/dist/pronto
   [6ms]  bundle  40 modules
  [92ms] compile  /private/tmp/pronto-v0.2.2-qualification/dist/s4imsg
- bun test v1.3.14 (0d9b296a) (227 passed)
- bun test v1.3.14 (0d9b296a)
release validation passed
- release qualification passed for v0.2.2
- exact installed candidate: one RCS activation, one confirmed exact reply, no retry or echo after one minute