### PR TITLE
fix: codesign the compiled binary so macOS arm64 can exec it (setup fails with 137)

### DIFF
--- a/packages/cli/src/macos/setup.ts
+++ b/packages/cli/src/macos/setup.ts
@@ -592,6 +592,23 @@ export function sourceBuild(repositoryRoot: string): (outputPath: string) => Pro
     if (result.exitCode !== 0) {
       throw new Error(`Unable to compile pronto: ${result.stderr.trim() || result.exitCode}`);
     }
+    // A stable identity + fixed identifier keeps the Designated Requirement constant
+    // across rebuilds, so the Full Disk Access grant survives. Ad-hoc ("-") pins TCC to
+    // the code hash instead, which bun's non-reproducible --compile invalidates every run.
+    const signingIdentity = process.env.PRONTO_CODESIGN_IDENTITY ?? "-";
+    const signature = await runCommand("/usr/bin/codesign", [
+      "--force",
+      "--sign",
+      signingIdentity,
+      "--identifier",
+      "dev.pronto.cli",
+      outputPath,
+    ]);
+    if (signature.exitCode !== 0) {
+      throw new Error(
+        `Unable to codesign pronto: ${signature.stderr.trim() || signature.exitCode}`,
+      );
+    }
   };
 }
 


### PR DESCRIPTION
## Problem

`pronto setup` fails on a clean from-source install on macOS arm64:

```
error: Installed Pronto qualification failed: 137
    at qualifyInstalledExecutable (packages/cli/src/macos/setup.ts:400:15)
```

137 is 128+9 (SIGKILL). `sourceBuild()` compiles via `bun build --compile` and installs
the output with no code-signing step. Bun 1.4.0's compiled arm64 output carries an invalid
signature, so AMFI kills the process on exec.

## Why the error is undiagnosable

`qualifyInstalledExecutable` reports `stderr || stdout || exitCode`. A signature kill
produces **neither stream**, so the user gets a bare `137` with no cause and no hint that
code signing is involved. Measured on the same source tree, only the signing step differing:

| Build | stdout + stderr | exit |
|---|---|---|
| `bun build --compile`, unsigned (current behaviour) | *(empty)* | **137** |
| same output, signed by this patch | `pronto 0.2.2` | **0** |

`codesign -v` on the unsigned output: `invalid signature (code or signature have been modified)`.

## Fix

Sign the compiled output before installing it. The identity is configurable via
`PRONTO_CODESIGN_IDENTITY` and defaults to ad-hoc (`-`), so the default path needs no
developer certificate and no configuration.

## Why a *stable* identity matters: FDA is silently voided on every setup run

`bun build --compile` is not reproducible — identical source produced sha256 `79d6bb97…`,
then `9859105b…`, then `fc04fee6…` on this machine. Ad-hoc signing pins the TCC record to
the code hash, so **every** `pronto setup` invalidates the existing Full Disk Access grant
even when nothing changed. Toggling the row off/on in System Settings does not recover it;
the row has to be removed and re-added.

Signing with a stable identity plus the fixed `--identifier dev.pronto.cli` keeps the
Designated Requirement constant across rebuilds, so a rebuilt binary keeps working under
the existing grant. Verified here: rebuilt twice, FDA held both times.

Users who set `PRONTO_CODESIGN_IDENTITY` to a real identity get that stability. Users on
the ad-hoc default are no worse off than today, and the 137 is fixed either way.

## Verification

- `bun test` — 227 pass / 0 fail
- `tsc --noEmit` — clean
- `sourceBuild()` exercised directly; output passes `codesign -v` and execs (`pronto 0.2.2`, exit 0)
- Control: same source without the signing step reproduces `137` with empty output

## Possible follow-up (not in this PR)

`qualifyInstalledExecutable` could special-case `137` with a message pointing at code
signing, so this failure mode is self-explanatory even if signing is ever bypassed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
