### PR TITLE
Harden source setup and refresh verified tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,7 +16,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
@@ -36,7 +36,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       prerelease: ${{ steps.release-version.outputs.prerelease }}
       release-tag: ${{ steps.release-version.outputs.release-tag }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
@@ -77,7 +77,7 @@ jobs:
           shasum -a 256 -c s4imsg.sha256
           shasum -a 256 "${{ steps.release-version.outputs.package-file }}" > pronto-imessage.sha256
           shasum -a 256 -c pronto-imessage.sha256
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pronto-macos
           retention-days: 1
@@ -115,7 +115,7 @@ jobs:
             echo "If a previous attempt left a draft, delete that draft explicitly before rerunning."
             exit 1
           fi
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pronto-macos
           path: release-assets

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ installs the `dev.pronto.agent` user LaunchAgent. It asks the owner to grant Ful
 Disk Access to that exact installed executable, verifies the installed identity,
 and reports success only after the new listener is healthy.
 
+Source setup replaces Bun's embedded macOS signature with an ad-hoc signature so
+the compiled executable can launch on supported macOS versions. If you have a
+stable code-signing identity and want Full Disk Access to survive recompilation,
+set `PRONTO_CODESIGN_IDENTITY` to that identity before running setup. The value is
+passed directly to `/usr/bin/codesign`; it is never evaluated by a shell.
+
 ## macOS permissions
 
 In System Settings → Privacy & Security:
@@ -193,10 +199,11 @@ bun run packages/cli/src/cli.ts setup
 ```
 
 Setup replaces the stable executable atomically and preserves configuration and
-bounded memory. macOS may treat the replacement as a new privacy identity; run
-`doctor` again after setup. If Pronto already appears in Full Disk Access,
-remove that entry and add the exact installed executable again; toggling the
-existing entry off and on does not refresh the replaced identity.
+bounded memory. An ad-hoc-signed replacement has a new privacy identity; run
+`doctor` again after setup. If Pronto already appears in Full Disk Access, remove
+that entry and add the exact installed executable again; toggling the existing
+entry off and on does not refresh the replaced identity. A stable identity set
+through `PRONTO_CODESIGN_IDENTITY` preserves the identity across recompilation.
 
 ## Troubleshooting
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,8 +6,9 @@
       "name": "pronto",
       "devDependencies": {
         "@types/bun": "1.3.14",
+        "@types/node": "26.2.0",
         "pronto-imessage": "workspace:*",
-        "typescript": "5.9.3",
+        "typescript": "7.0.2",
       },
     },
     "packages/cli": {
@@ -31,13 +32,53 @@
 
     "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "pronto-cli": ["pronto-cli@workspace:packages/cli"],
 
     "pronto-imessage": ["pronto-imessage@workspace:packages/messages"],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "devDependencies": {
     "@types/bun": "1.3.14",
+    "@types/node": "26.2.0",
     "pronto-imessage": "workspace:*",
-    "typescript": "5.9.3"
+    "typescript": "7.0.2"
   }
 }

--- a/packages/cli/src/macos/setup.ts
+++ b/packages/cli/src/macos/setup.ts
@@ -580,9 +580,13 @@ export interface SetupDependencies {
   saveConfiguration?: (path: string, config: ProntoConfig) => Promise<void>;
 }
 
-export function sourceBuild(repositoryRoot: string): (outputPath: string) => Promise<void> {
+export function sourceBuild(
+  repositoryRoot: string,
+  runner: CommandRunner = runCommand,
+  signingIdentity: string = process.env.PRONTO_CODESIGN_IDENTITY?.trim() || "-",
+): (outputPath: string) => Promise<void> {
   return async (outputPath) => {
-    const result = await runCommand(Bun.which("bun") ?? "bun", [
+    const result = await runner(Bun.which("bun") ?? "bun", [
       "build",
       join(repositoryRoot, "packages", "cli", "src", "cli.ts"),
       "--compile",
@@ -591,6 +595,29 @@ export function sourceBuild(repositoryRoot: string): (outputPath: string) => Pro
     ]);
     if (result.exitCode !== 0) {
       throw new Error(`Unable to compile pronto: ${result.stderr.trim() || result.exitCode}`);
+    }
+    const signature = await runner("/usr/bin/codesign", [
+      "--force",
+      "--sign",
+      signingIdentity,
+      "--identifier",
+      "dev.pronto.cli",
+      outputPath,
+    ]);
+    if (signature.exitCode !== 0) {
+      throw new Error(
+        `Unable to code-sign pronto: ${signature.stderr.trim() || signature.exitCode}`,
+      );
+    }
+    const verification = await runner("/usr/bin/codesign", [
+      "--verify",
+      "--strict",
+      outputPath,
+    ]);
+    if (verification.exitCode !== 0) {
+      throw new Error(
+        `Unable to verify pronto code signature: ${verification.stderr.trim() || verification.exitCode}`,
+      );
     }
   };
 }

--- a/packages/messages/tsconfig.json
+++ b/packages/messages/tsconfig.json
@@ -10,7 +10,8 @@
     "rootDir": "src",
     "sourceMap": true,
     "strict": true,
-    "target": "ES2022"
+    "target": "ES2022",
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"]
 }

--- a/test/unit/setup.test.ts
+++ b/test/unit/setup.test.ts
@@ -18,6 +18,7 @@ import {
   qualifyInstalledExecutable,
   resolveWorkspaceSelection,
   setupCompletionMessage,
+  sourceBuild,
   uninstallInstallation,
 } from "../../packages/cli/src/macos/setup";
 
@@ -663,6 +664,85 @@ test("migration resumes finalization after legacy plist removal is interrupted",
     join(paths.appSupportDirectory, "migration-backup", "completed"),
     "utf8",
   )).toContain("completed");
+});
+
+test("source builds replace Bun's embedded signature before installation", async () => {
+  const calls: Array<{ executable: string; args: readonly string[] }> = [];
+  const build = sourceBuild(
+    "/Users/example/pronto",
+    async (executable, args) => {
+      calls.push({ executable, args });
+      return { exitCode: 0, stderr: "", stdout: "" };
+    },
+    "Developer ID Application: Example",
+  );
+
+  await build("/private/tmp/pronto");
+
+  expect(calls).toEqual([
+    {
+      executable: Bun.which("bun") ?? "bun",
+      args: [
+        "build",
+        "/Users/example/pronto/packages/cli/src/cli.ts",
+        "--compile",
+        "--outfile",
+        "/private/tmp/pronto",
+      ],
+    },
+    {
+      executable: "/usr/bin/codesign",
+      args: [
+        "--force",
+        "--sign",
+        "Developer ID Application: Example",
+        "--identifier",
+        "dev.pronto.cli",
+        "/private/tmp/pronto",
+      ],
+    },
+    {
+      executable: "/usr/bin/codesign",
+      args: ["--verify", "--strict", "/private/tmp/pronto"],
+    },
+  ]);
+});
+
+test("source builds do not sign output after compilation fails", async () => {
+  const calls: string[] = [];
+  const build = sourceBuild("/Users/example/pronto", async (executable) => {
+    calls.push(executable);
+    return { exitCode: 1, stderr: "compile failed", stdout: "" };
+  });
+
+  await expect(build("/private/tmp/pronto")).rejects.toThrow(
+    "Unable to compile pronto: compile failed",
+  );
+  expect(calls).toEqual([Bun.which("bun") ?? "bun"]);
+});
+
+test("source builds fail closed when the replacement signature fails", async () => {
+  const build = sourceBuild("/Users/example/pronto", async (executable, args) => {
+    return executable === "/usr/bin/codesign" && args[0] === "--force"
+      ? { exitCode: 1, stderr: "identity unavailable", stdout: "" }
+      : { exitCode: 0, stderr: "", stdout: "" };
+  });
+
+  await expect(build("/private/tmp/pronto")).rejects.toThrow(
+    "Unable to code-sign pronto: identity unavailable",
+  );
+});
+
+test("source builds fail closed when the replacement signature is invalid", async () => {
+  const build = sourceBuild("/Users/example/pronto", async (executable, args) => {
+    return executable === "/usr/bin/codesign" && args[0] === "--verify"
+      ? { exitCode: 1, stderr: "invalid signature", stdout: "" }
+      : { exitCode: 0, stderr: "", stdout: "" };
+  });
+
+  await expect(build("/private/tmp/pronto")).rejects.toThrow(
+    "Unable to verify pronto code signature: invalid signature",
+  );
 });
 
 test("installed qualification runs doctor through the exact installed executable", async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "baseUrl": ".",
     "paths": {
       "pronto-imessage": ["./packages/messages/src/index.ts"]
     },


### PR DESCRIPTION
Independently incorporates the valid improvements from the open backlog without merging contributor branches.

- replaces and strictly verifies Bun compiled-executable signatures during source setup
- documents ad-hoc and stable signing identity behavior
- updates checkout and artifact actions to verified immutable release SHAs
- completes the TypeScript 7 migration, including its required config and explicit Node type updates
- retains Bun 1.3.14 types to match the supported and qualified runtime floor

Validation: frozen install with scripts disabled, typecheck, 231 tests, compiled build, release validation, strict macOS signature verification and execution, dependency audit, and diff check all pass.