### PR TITLE
Build release artifacts before Pages validation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,6 +22,7 @@ jobs:
           bun-version: 1.3.14
       - run: bun install --frozen-lockfile
       - run: bun test test/unit/site.test.ts test/unit/workflow-validation.test.ts
+      - run: bun run build
       - run: bun run release:validate
 
   deploy:

--- a/test/unit/site.test.ts
+++ b/test/unit/site.test.ts
@@ -285,6 +285,9 @@ describe("public landing page", () => {
     expect(workflow).toContain("if: github.ref == 'refs/heads/main'");
     expect(workflow).toContain("actions/upload-pages-artifact@");
     expect(workflow).toContain("actions/deploy-pages@");
+    expect(workflow.indexOf("- run: bun run build")).toBeLessThan(
+      workflow.indexOf("- run: bun run release:validate"),
+    );
   });
 
   test("keeps the hero minimal and points to the setup prompt", async () => {


### PR DESCRIPTION
Repairs the pre-existing Pages verification failure by building the release artifacts before release validation. Adds a regression assertion that preserves the required ordering.

Validation: frozen install with scripts disabled, focused Pages and workflow tests, compiled build, release validation, and diff check all pass.