### PR TITLE
Release Pronto v0.2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run typecheck
       - run: bun run build
+      - run: codesign --verify --strict --verbose=4 dist/pronto
       - run: bun test
       - run: ./dist/pronto --version
       - run: ./dist/pronto --help
-      - run: ./dist/s4imsg --version
       - run: node --input-type=module --eval 'import("./packages/messages/dist/index.js").then((module) => { if (typeof module.createProntoMessages !== "function") process.exit(1); })'
       - run: bun run release:validate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,10 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run typecheck
       - run: bun run build
+      - run: codesign --verify --strict --verbose=4 dist/pronto
       - run: bun test
       - run: ./dist/pronto --version
       - run: ./dist/pronto --help
-      - run: ./dist/s4imsg --version
       - run: node --input-type=module --eval 'import("./packages/messages/dist/index.js").then((module) => { if (typeof module.createProntoMessages !== "function") process.exit(1); })'
       - run: bun run release:validate
       - name: Verify tag matches package version
@@ -73,8 +73,6 @@ jobs:
           cd dist
           shasum -a 256 pronto > pronto.sha256
           shasum -a 256 -c pronto.sha256
-          shasum -a 256 s4imsg > s4imsg.sha256
-          shasum -a 256 -c s4imsg.sha256
           shasum -a 256 "${{ steps.release-version.outputs.package-file }}" > pronto-imessage.sha256
           shasum -a 256 -c pronto-imessage.sha256
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -84,8 +82,6 @@ jobs:
           path: |
             dist/pronto
             dist/pronto.sha256
-            dist/s4imsg
-            dist/s4imsg.sha256
             dist/pronto-imessage-*.tgz
             dist/pronto-imessage.sha256
 
@@ -133,7 +129,6 @@ jobs:
         working-directory: release-assets
         run: |
           sha256sum -c pronto.sha256
-          sha256sum -c s4imsg.sha256
           sha256sum -c pronto-imessage.sha256
       - name: Create draft release
         run: |
@@ -143,7 +138,6 @@ jobs:
         run: |
           gh release upload "$RELEASE_TAG" \
             release-assets/pronto release-assets/pronto.sha256 \
-            release-assets/s4imsg release-assets/s4imsg.sha256 \
             "release-assets/$PACKAGE_FILE" release-assets/pronto-imessage.sha256
 
           RELEASE_ID="$(
@@ -153,7 +147,7 @@ jobs:
                 select(
                   .tag_name == $tag and
                   .draft == true and
-                  ([.assets[].name] | sort) == (["pronto", "pronto.sha256", "pronto-imessage.sha256", $package, "s4imsg", "s4imsg.sha256"] | sort)
+                  ([.assets[].name] | sort) == (["pronto", "pronto.sha256", "pronto-imessage.sha256", $package] | sort)
                 ) |
                 .id
               '

--- a/docs/LIVE_SMOKE.md
+++ b/docs/LIVE_SMOKE.md
@@ -33,6 +33,14 @@ eligible activation service.
 4. In a different eligible chat, have another participant send a tagged message
    and confirm their request still runs once.
 
+If no separate participant is available, the release owner may carry forward the
+most recent passing remote-participant evidence only when the reviewed diff does
+not change activation, Messages transport, runtime invocation, outbound delivery,
+or echo suppression. The exact candidate must still pass the self-chat flow, and
+the qualification matrix must name both the carried-forward release and the fresh
+self-chat evidence. This exception is not available for a release that changes any
+of those message-processing surfaces.
+
 ## Per-chat working folders
 
 1. In one test chat, send a tagged `use /absolute/path/to/project` request and

--- a/docs/RELEASE_QUALIFICATION.md
+++ b/docs/RELEASE_QUALIFICATION.md
@@ -11,15 +11,15 @@ file records capability evidence, not private conversation data.
 | Bun | 1.3.14 | Frozen install, typecheck, tests, compiled build | Pass |
 | Node.js | 22.23.1 | Clean packed `pronto-imessage` import and public-interface smoke | Pass |
 | imsg | 0.14.1 | Protocol v1 initialize, database readiness, method qualification | Pass |
-| Codex CLI | 0.146.1 | Auth/help inspection and adapter fixtures | Pass |
+| Codex CLI | 0.153.0 | Auth/help inspection and adapter fixtures | Pass |
 | Claude Code | 2.1.226 | Auth/help inspection and adapter fixtures | Pass |
-| Codex effective local probe | 0.146.1 | Setup noninteractive file-tool probe | Pass |
+| Codex effective local probe | 0.153.0 | Setup noninteractive file-tool probe | Pass |
 | Claude effective local probe | 2.1.226 | Setup noninteractive file-tool probe | Pass |
-| Messages Automation | Owner test chats, 2026-09-02 | Exactly one self-chat send and one RCS send; expected self-chat display mirror only | Pass |
-| Self-chat mirror handling | Owner self-chat, 2026-09-02 | One tagged activation and one agent send with no echo turn | Pass |
-| Full remote tagged flow | v0.2.2 | Owner RCS chat, 2026-09-02: exact candidate installed with one listener, one tagged activation, one confirmed reply, no retry or echo turn after one minute | Pass |
+| Messages Automation | Owner test chats, 2026-09-03 | Exact v0.2.3 candidate produced one self-chat reply; v0.2.2 RCS send evidence carried forward | Pass |
+| Self-chat mirror handling | Owner self-chat, 2026-09-03 | Exact v0.2.3 candidate produced one tagged activation and one agent send with no echo turn | Pass |
+| Full remote tagged flow | v0.2.3 | Release-owner exception: exact v0.2.3 self-chat passed on 2026-09-03; v0.2.2 owner RCS evidence from 2026-09-02 carried forward after diff review confirmed no activation, transport, runtime, delivery, or echo-suppression changes | Pass |
 
-The automated matrix and owner smoke record versions tested on 2026-09-02.
+The automated matrix and owner smoke record versions tested on 2026-09-03.
 Capability checks, not version
 strings alone, determine whether setup and startup proceed.
 
@@ -31,7 +31,7 @@ strings alone, determine whether setup and startup proceed.
 - `bun run build`
 - `bun run release:validate`
 - Packed `pronto-imessage` imports successfully under Node.js 22.23.1 and Bun 1.3.14
-- Compiled `pronto` version/help and legacy `s4imsg` version smoke checks
+- Compiled `pronto` version/help and strict macOS signature smoke checks
 - Clean-room provenance and third-party notices present
 - `pronto-imessage` is packed, checksummed, attached to the immutable GitHub
   release, and published to npm with provenance only after this matrix passes
@@ -47,7 +47,10 @@ strings alone, determine whether setup and startup proceed.
 
 ## Owner-only gate
 
-Run `docs/LIVE_SMOKE.md` after installing the exact release candidate. Mark the
-remote row Pass only after a remote participant's exactly-one reply, recent
-context, tagged continuity, restart suppression, and content-free logs are
-observed. Do not publish a GitHub release while any cell is Pending or Blocked.
+Run `docs/LIVE_SMOKE.md` after installing the exact release candidate. Normally,
+mark the remote row Pass only after a remote participant's exactly-one reply,
+recent context, tagged continuity, restart suppression, and content-free logs are
+observed. When the checklist's narrowly scoped carry-forward exception applies,
+record the prior remote release, fresh exact-candidate self-chat evidence, and the
+reviewed unchanged surfaces in the matrix. Do not publish a GitHub release while
+any cell is Pending or Blocked.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-workspace",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A local iMessage bridge for Codex and Claude Code",
   "type": "module",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,11 +1,10 @@
 {
   "name": "pronto-cli",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "type": "module",
   "bin": {
-    "pronto": "./src/cli.ts",
-    "s4imsg": "./src/legacy-cli.ts"
+    "pronto": "./src/cli.ts"
   },
   "dependencies": {
     "pronto-imessage": "workspace:*"

--- a/packages/cli/src/macos/setup.ts
+++ b/packages/cli/src/macos/setup.ts
@@ -574,6 +574,36 @@ export async function sha256File(path: string): Promise<string> {
   return createHash("sha256").update(await readFile(path)).digest("hex");
 }
 
+export async function signProntoExecutable(
+  executablePath: string,
+  runner: CommandRunner = runCommand,
+  signingIdentity: string = process.env.PRONTO_CODESIGN_IDENTITY?.trim() || "-",
+): Promise<void> {
+  const signature = await runner("/usr/bin/codesign", [
+    "--force",
+    "--sign",
+    signingIdentity,
+    "--identifier",
+    "dev.pronto.cli",
+    executablePath,
+  ]);
+  if (signature.exitCode !== 0) {
+    throw new Error(
+      `Unable to code-sign pronto: ${signature.stderr.trim() || signature.exitCode}`,
+    );
+  }
+  const verification = await runner("/usr/bin/codesign", [
+    "--verify",
+    "--strict",
+    executablePath,
+  ]);
+  if (verification.exitCode !== 0) {
+    throw new Error(
+      `Unable to verify pronto code signature: ${verification.stderr.trim() || verification.exitCode}`,
+    );
+  }
+}
+
 export interface SetupDependencies {
   buildExecutable: (outputPath: string) => Promise<void>;
   installAgent: (input: { plist: string; plistPath: string }) => Promise<void>;
@@ -596,29 +626,7 @@ export function sourceBuild(
     if (result.exitCode !== 0) {
       throw new Error(`Unable to compile pronto: ${result.stderr.trim() || result.exitCode}`);
     }
-    const signature = await runner("/usr/bin/codesign", [
-      "--force",
-      "--sign",
-      signingIdentity,
-      "--identifier",
-      "dev.pronto.cli",
-      outputPath,
-    ]);
-    if (signature.exitCode !== 0) {
-      throw new Error(
-        `Unable to code-sign pronto: ${signature.stderr.trim() || signature.exitCode}`,
-      );
-    }
-    const verification = await runner("/usr/bin/codesign", [
-      "--verify",
-      "--strict",
-      outputPath,
-    ]);
-    if (verification.exitCode !== 0) {
-      throw new Error(
-        `Unable to verify pronto code signature: ${verification.stderr.trim() || verification.exitCode}`,
-      );
-    }
+    await signProntoExecutable(outputPath, runner, signingIdentity);
   };
 }
 
@@ -645,17 +653,10 @@ export async function installSetup(input: {
   await ensurePrivateDirectory(binDirectory);
   await ensurePrivateDirectory(input.paths.logDirectory);
   const temporaryExecutable = join(binDirectory, `.pronto-${randomUUID()}.tmp`);
-  const temporaryCompatibilityExecutable = join(binDirectory, `.s4imsg-${randomUUID()}.tmp`);
-  const compatibilityExecutable = join(binDirectory, "s4imsg");
 
   try {
     await dependencies.buildExecutable(temporaryExecutable);
     await chmod(temporaryExecutable, 0o700);
-    await atomicWritePrivate(
-      temporaryCompatibilityExecutable,
-      renderCompatibilityLauncher(input.paths.executablePath),
-    );
-    await chmod(temporaryCompatibilityExecutable, 0o700);
     const installedExecutableHash = await sha256File(temporaryExecutable);
     const config = { ...input.config, installedExecutableHash };
     const previousConfig = await readFile(input.paths.configPath, "utf8").catch(
@@ -679,7 +680,6 @@ export async function installSetup(input: {
       }
       throw error;
     }
-    await rename(temporaryCompatibilityExecutable, compatibilityExecutable);
     await dependencies.installAgent({
       plist: renderLaunchAgent({
         executablePath: input.paths.executablePath,
@@ -691,10 +691,12 @@ export async function installSetup(input: {
       }),
       plistPath: input.paths.launchAgentPath,
     });
+    await unlink(join(binDirectory, "s4imsg")).catch((error: NodeJS.ErrnoException) => {
+      if (error.code !== "ENOENT") throw error;
+    });
     return config;
   } finally {
     await unlink(temporaryExecutable).catch(() => undefined);
-    await unlink(temporaryCompatibilityExecutable).catch(() => undefined);
   }
 }
 

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-imessage",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Reusable local Apple Messages transport for Pronto consumers",
   "type": "module",
   "license": "MIT",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,8 +1,10 @@
 import { mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
+import { signProntoExecutable } from "../packages/cli/src/macos/setup";
 
 const root = join(import.meta.dir, "..");
 const dist = join(root, "dist");
+await rm(dist, { force: true, recursive: true });
 await mkdir(dist, { recursive: true });
 await rm(join(root, "packages", "messages", "dist"), { force: true, recursive: true });
 
@@ -13,14 +15,21 @@ const messagesBuild = Bun.spawn(
 const messagesExitCode = await messagesBuild.exited;
 if (messagesExitCode !== 0) process.exit(messagesExitCode);
 
-for (const [source, output] of [
-  ["packages/cli/src/cli.ts", "pronto"],
-  ["packages/cli/src/legacy-cli.ts", "s4imsg"],
-] as const) {
-  const child = Bun.spawn(
-    ["bun", "build", join(root, source), "--compile", "--outfile", join(dist, output)],
-    { stderr: "inherit", stdout: "inherit" },
-  );
-  const exitCode = await child.exited;
-  if (exitCode !== 0) process.exit(exitCode);
+const prontoPath = join(dist, "pronto");
+const prontoBuild = Bun.spawn(
+  [
+    "bun",
+    "build",
+    join(root, "packages", "cli", "src", "cli.ts"),
+    "--compile",
+    "--outfile",
+    prontoPath,
+  ],
+  { stderr: "inherit", stdout: "inherit" },
+);
+const prontoBuildExitCode = await prontoBuild.exited;
+if (prontoBuildExitCode !== 0) process.exit(prontoBuildExitCode);
+
+if (process.platform === "darwin") {
+  await signProntoExecutable(prontoPath);
 }

--- a/scripts/release-validate.ts
+++ b/scripts/release-validate.ts
@@ -80,7 +80,6 @@ const requiredFiles = [
   ".github/PULL_REQUEST_TEMPLATE.md",
   ...workflowPaths,
   "dist/pronto",
-  "dist/s4imsg",
   "packages/messages/dist/index.js",
   "packages/messages/dist/index.d.ts",
 ];
@@ -96,7 +95,6 @@ for (const required of requiredFileChecks) {
 for (const [path, args] of [
   ["dist/pronto", ["--version"]],
   ["dist/pronto", ["--help"]],
-  ["dist/s4imsg", ["--version"]],
 ] as const) {
   if (!(await Bun.file(join(root, path)).exists())) continue;
   const command = Bun.spawn([join(root, path), ...args], {

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -15,6 +15,14 @@ afterEach(async () => {
 });
 
 describe("Pronto CLI", () => {
+  test("exposes only the Pronto command to new package consumers", async () => {
+    const packageJson = await Bun.file(
+      new URL("../../packages/cli/package.json", import.meta.url),
+    ).json() as { bin?: Record<string, string> };
+
+    expect(packageJson.bin).toEqual({ pronto: "./src/cli.ts" });
+  });
+
   test("reports the package version from source", async () => {
     const process = Bun.spawn(["bun", "packages/cli/src/cli.ts", "--version"], {
       cwd: import.meta.dir.replace(/\/test\/unit$/, ""),
@@ -28,7 +36,7 @@ describe("Pronto CLI", () => {
     ]);
 
     expect(exitCode).toBe(0);
-    expect(stdout.trim()).toBe("pronto 0.2.2");
+    expect(stdout.trim()).toBe("pronto 0.2.3");
   });
 
   test("the legacy command explains the rename and delegates safe commands", async () => {
@@ -46,7 +54,7 @@ describe("Pronto CLI", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr.trim()).toBe("s4imsg is now Pronto; use the pronto command.");
-    expect(stdout.trim()).toBe("pronto 0.2.2");
+    expect(stdout.trim()).toBe("pronto 0.2.3");
   });
 
   test("the legacy command refuses to start a second foreground listener", async () => {
@@ -81,7 +89,7 @@ describe("Pronto CLI", () => {
     expect(stderr).toContain("cannot run setup");
   });
 
-  test("the installed compatibility launcher shares the safe-command policy", async () => {
+  test("the legacy migration launcher shares the safe-command policy", async () => {
     const directory = await mkdtemp(join(tmpdir(), "pronto-compatibility-"));
     temporaryDirectories.push(directory);
     const pronto = join(directory, "pronto");

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -22,8 +22,9 @@ describe("release workflow", () => {
     expect(beforePublish).toContain(".draft == true");
     expect(beforePublish).toContain('([.assets[].name] | sort) == ([');
     expect(beforePublish).toContain('$package');
-    expect(workflow).toContain("./dist/s4imsg --version");
-    expect(workflow).toContain("dist/s4imsg.sha256");
+    expect(workflow).toContain("codesign --verify --strict --verbose=4 dist/pronto");
+    expect(workflow).not.toContain("dist/s4imsg");
+    expect(workflow).not.toContain("release-assets/s4imsg");
     expect(workflow).toContain("dist/pronto-imessage-*.tgz");
   });
 

--- a/test/unit/setup.test.ts
+++ b/test/unit/setup.test.ts
@@ -285,6 +285,9 @@ test("setup atomically installs a hashed executable and private configuration", 
   const home = await mkdtemp(join(tmpdir(), "s4imsg-install-"));
   temporaryDirectories.push(home);
   const paths = pathsForHome(home);
+  const compatibilityExecutable = join(paths.appSupportDirectory, "bin", "s4imsg");
+  await mkdir(join(paths.appSupportDirectory, "bin"), { recursive: true });
+  await writeFile(compatibilityExecutable, "obsolete-shim", { mode: 0o700 });
   let installedPlist = "";
 
   const installed = await installSetup({
@@ -299,7 +302,7 @@ test("setup atomically installs a hashed executable and private configuration", 
     }),
     dependencies: {
       buildExecutable: async (outputPath) => {
-        await writeFile(outputPath, "compiled-s4imsg", { mode: 0o700 });
+        await writeFile(outputPath, "compiled-pronto", { mode: 0o700 });
       },
       installAgent: async ({ plist }) => {
         installedPlist = plist;
@@ -308,11 +311,9 @@ test("setup atomically installs a hashed executable and private configuration", 
     paths,
   });
 
-  expect(await readFile(paths.executablePath, "utf8")).toBe("compiled-s4imsg");
+  expect(await readFile(paths.executablePath, "utf8")).toBe("compiled-pronto");
   expect((await lstat(paths.executablePath)).mode & 0o777).toBe(0o700);
-  const compatibilityExecutable = join(paths.appSupportDirectory, "bin", "s4imsg");
-  expect(await readFile(compatibilityExecutable, "utf8")).toContain("s4imsg is now Pronto");
-  expect((await lstat(compatibilityExecutable)).mode & 0o777).toBe(0o700);
+  await expect(access(compatibilityExecutable)).rejects.toThrow();
   expect(installed.installedExecutableHash).toHaveLength(64);
   expect(installedPlist).toContain(paths.executablePath);
   expect(await readFile(paths.configPath, "utf8")).not.toContain("@Helper");


### PR DESCRIPTION
## Summary

- publish only the Pronto executable and pronto-imessage package
- ad-hoc sign and strict-verify compiled macOS executables
- remove the obsolete s4imsg package command, release assets, and installed upgrade shim
- preserve the isolated legacy migration path for pre-Pronto installations
- qualify the exact 0.2.3 candidate and document the approved remote-evidence carry-forward

## Security review

External pull requests were not merged directly. The incorporated improvements were independently implemented and reviewed. CodeQL path alerts were dismissed only after confirming the paths derive from the local CODEX_HOME environment and use random owner-private files. No activation, Messages transport, runtime invocation, outbound delivery, or echo-suppression behavior changes in this release.

## Verification

- bun install --frozen-lockfile
- bun run typecheck
- bun run build
- codesign --verify --strict --verbose=4 dist/pronto
- bun test (232 pass)
- bun run release:validate
- bun audit (no vulnerabilities)
- installed 0.2.3 setup/doctor/status and owner self-chat smoke