### PR TITLE
Harden imsg provider reliability

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
     },
     "packages/cli": {
       "name": "pronto-cli",
-      "version": "0.2.2",
+      "version": "0.2.4",
       "bin": {
         "pronto": "./src/cli.ts",
         "s4imsg": "./src/legacy-cli.ts",
@@ -24,7 +24,7 @@
     },
     "packages/messages": {
       "name": "pronto-imessage",
-      "version": "0.2.2",
+      "version": "0.2.4",
     },
   },
   "packages": {

--- a/docs/research/2026-09-04-imsg-upstream-delta.md
+++ b/docs/research/2026-09-04-imsg-upstream-delta.md
@@ -1,0 +1,143 @@
+# `imsg` upstream delta for Pronto 0.2.3
+
+- **Research date:** 2026-09-04
+- **Pronto baseline:** [`v0.2.3`](https://github.com/eabnelson/pronto/tree/v0.2.3), commit `8cb7659`
+- **Upstream baseline:** [`imsg` v0.14.1](https://github.com/openclaw/imsg/releases/tag/v0.14.1), commit `25beb76`
+- **Latest release:** [`imsg` v0.15.0](https://github.com/openclaw/imsg/releases/tag/v0.15.0), commit `f2fad4c`, published 2026-09-04 UTC
+- **Upstream `main` inspected:** [`cdc09c1`](https://github.com/openclaw/imsg/tree/cdc09c1f2de8d13bf0052f472b810f35048f1557)
+
+This report compares the official [`v0.14.1...v0.15.0`](https://github.com/openclaw/imsg/compare/v0.14.1...v0.15.0) change set and the unreleased [`v0.15.0...cdc09c1`](https://github.com/openclaw/imsg/compare/v0.15.0...cdc09c1f2de8d13bf0052f472b810f35048f1557) changes with Pronto's local Messages module. It uses upstream release notes, documentation, source, and tests plus the local Pronto source; it does not treat untagged upstream code as a releasable dependency.
+
+## Bottom line
+
+`imsg` v0.15.0 does not break Pronto's current public read/watch/send contract. RPC remains protocol version 1, every method Pronto requires remains available in SIP-on mode when `chat.db` is readable, request keys and core response fields are unchanged, and the new fields/methods are additive. Pronto's capability-based qualifier is therefore structurally compatible with v0.15.0 ([Pronto qualifier](../../packages/messages/src/internal/normalize.ts#L8-L52), [`imsg` status contract](https://github.com/openclaw/imsg/blob/v0.15.0/docs/rpc.md#status)).
+
+It is not yet production-qualified. Pronto v0.2.3's evidence matrix covers `imsg` 0.14.1 only ([release qualification](../RELEASE_QUALIFICATION.md#current-matrix)). More importantly, upstream `main` gained twelve fixes immediately after v0.15.0, including watch replay, attributed-body decoding, physical-message cardinality, subscription cleanup, and send-route verification. Those are precisely the surfaces Pronto uses. Prefer the next signed release containing those fixes; if v0.15.0 must ship first, run the focused live and synthetic matrix below and record the known gap explicitly.
+
+## Priority summary
+
+| Priority | Recommendation | Why |
+| --- | --- | --- |
+| Must | Keep 0.14.1 as the recorded production-qualified version until an exact v0.15.0/next-release matrix passes | Source compatibility is not live evidence, and post-tag fixes touch Pronto-critical paths |
+| Must | Fix Pronto's RPC error-data mapping | Upstream uses `retryable` for database/bridge availability but Pronto checks only `retry_safe` |
+| Must | Honor upstream's EOF drain instead of immediately sending `SIGTERM` | Current shutdown can interrupt an accepted mutation and manufacture ambiguity |
+| Must | Separate message-level `destination_caller_id` from chat-level `last_addressed_handle` | Pronto currently drops the stronger per-message routing fact |
+| Must | Correct the zero-cursor handoff and stale-row recovery behavior | `messages.after(0)` and `watch.subscribe(0)` have different meanings; the current age abort can skip newer eligible rows |
+| Should | Add exact v0.14.2+ direct-chat recovery coverage | The fix benefits Pronto's `chat_id` text and attachment replies without an API change |
+| Should | Preserve a richer capability/diagnostic snapshot and bounded sanitized stderr | Optional features must follow current readiness; today stderr is discarded |
+| Should | Harden group evidence for downstream consumers | `is_group` is identifier-shape-derived; external participant evidence should prevent unsafe direct-chat classification |
+| Defer | `send.tracked`, private bridge actions, contact names, chat creation, polls, and SSH transport | They either require a new security/effect contract or do not serve Pronto's current product path |
+
+## Compatibility after v0.14.1
+
+### Compatible and beneficial
+
+- **v0.14.2 direct-chat recovery:** a direct conversation missing from Messages.app's live cache can be recovered only through one database-verified participant on the original account and service. The behavior also applies when a direct chat is selected by `chat_id`, `chat_guid`, or `chat_identifier`; groups and unverified targets do not use it ([implementation](https://github.com/openclaw/imsg/commit/7c55ba5e79f1b70052e38991d4cadbd0d34c7836), [send contract](https://github.com/openclaw/imsg/blob/v0.15.0/docs/send.md#direct-sends)). Pronto already sends replies by exact `chat_id` in [`reply`](../../packages/messages/src/index.ts#L555-L583), so this is a transparent reliability improvement.
+- **Headless Contacts behavior:** v0.14.2 prevents noninteractive watch/search startup from waiting on an unresolved Contacts prompt; v0.15.0 adds read-only AddressBook resolution over SSH with Full Disk Access ([v0.15.0 release](https://github.com/openclaw/imsg/releases/tag/v0.15.0), [permissions](https://github.com/openclaw/imsg/blob/v0.15.0/docs/permissions.md#contacts-over-ssh)). Pronto routes on IDs, GUIDs, account metadata, and handles rather than contact names, so the added names are non-authoritative and harmless.
+- **Chat-name schema refinement:** `chats.list.name` is now a Messages title or raw identifier fallback; a resolved person name stays in `contact_name` ([change](https://github.com/openclaw/imsg/commit/c1bc060305f192a15fefe080283bea84c3f9189a)). Pronto ignores both fields and continues to use `id`, `guid`, `account_id`, `account_login`, `last_addressed_handle`, and participants.
+- **Dynamic capability status:** v0.15.0 reports a hung injected helper as unavailable and only advertises `send.tracked` when the database and `clientMessageGuidReservation` selector are ready ([descriptor](https://github.com/openclaw/imsg/blob/v0.15.0/Sources/imsg/RPCMethodDescriptors.swift#L107-L139), [status semantics](https://github.com/openclaw/imsg/blob/v0.15.0/docs/rpc.md#status)). Pronto correctly validates `status.methods`, not `supported_methods`, and tolerates additive methods.
+- **Poll-caption result fields and first-contact group creation** are additive bridge-only behavior. They do not change Pronto's public RPC requests or response parsing ([v0.15.0 RPC](https://github.com/openclaw/imsg/blob/v0.15.0/docs/rpc.md)).
+
+### No automatic version blocker inside Pronto
+
+Pronto's README deliberately permits “0.14 or a capability-compatible release,” and [`qualify`](../../packages/messages/src/internal/normalize.ts#L26-L52) checks protocol, current methods, database readiness, routing metadata, and optional database features rather than an exact version. That is the right compatibility boundary. The remaining 0.14.1 reference is evidence, not a runtime pin, and should change only after qualification.
+
+## Must fix in Pronto
+
+### 1. Map upstream retryability fields correctly
+
+Pronto's [`reply`](../../packages/messages/src/index.ts#L555-L583) interprets delivery failures correctly when `data.disposition` and `data.retry_safe` are present. It treats every other RPC error as retryable only when `data.retry_safe === true`.
+
+Upstream uses two schemas:
+
+- Transport delivery failures carry `retry_safe` plus `not_started`, `may_have_completed`, or `still_in_flight`.
+- Availability failures such as database unavailable (`-32002`) and bridge unavailable (`-32003`) carry `retryable: true`, not `retry_safe` ([upstream error construction](https://github.com/openclaw/imsg/blob/v0.15.0/Sources/imsg/RPCServer%2BSupport.swift#L80-L135)). An exact `chat_id` send requires the database, so `-32002` occurs before dispatch and is safe to retry after the database recovers ([send contract](https://github.com/openclaw/imsg/blob/v0.15.0/docs/rpc.md#send)).
+
+Pronto 0.2.3 therefore reports a provider-declared retryable database outage as `{status:"failed", retryable:false}`. Map typed delivery disposition first; then map `data.retryable === true` for the documented availability codes. Treat `-32000` server-busy as a bounded-backoff retry only when it is the response to Pronto's request: upstream rejects excess identified work before admission ([runtime test](https://github.com/openclaw/imsg/blob/v0.15.0/Tests/imsgTests/RPCRuntimeTests.swift#L401-L429)). Keep all unknown errors non-retryable.
+
+### 2. Let normal EOF drain accepted work
+
+`imsg rpc` stops admitting work when stdin closes, cancels and awaits subscriptions, drains already accepted requests—including queued mutations—and flushes stdout before exiting ([lifecycle](https://github.com/openclaw/imsg/blob/v0.15.0/docs/rpc.md#lifecycle)). Pronto's [`ImsgRpcClient.close`](../../packages/messages/src/internal/rpc.ts#L112-L118) closes stdin and immediately sends `SIGTERM`. That defeats the upstream guarantee and can turn a controlled daemon stop or update into an avoidable ambiguous send.
+
+End stdin, wait a short bounded grace period for exit and final responses, then escalate to `SIGTERM` and `SIGKILL`. A test should keep a mutation pending across EOF, prove its final response is consumed, and separately prove a hung child cannot block shutdown. Preserve the existing no-replay behavior for any response that is actually lost.
+
+### 3. Preserve the actual local routing fact
+
+`imsg` distinguishes chat-level routing diagnostics (`account_id`, `account_login`, `last_addressed_handle`) from the outbound message's `destination_caller_id`, which says which local number Messages actually used ([group/routing model](https://github.com/openclaw/imsg/blob/v0.15.0/docs/groups.md#participants-exclude-the-local-user)).
+
+Pronto currently derives `routing.destinationHandle` from `chat.last_addressed_handle` and does not carry `message.destination_caller_id` into `MessagesEvent` ([normalization](../../packages/messages/src/internal/normalize.ts#L81-L127), [public types](../../packages/messages/src/types.ts#L16-L69)). Split these fields. Keep the chat hint for route diagnostics; add the nullable message-level destination caller ID as the only evidence of the alias used for that outbound row. Consumers must not present the chat hint as positive message-level identity proof.
+
+### 4. Correct cursor-zero and age-bound semantics
+
+`messages.after` defines `since_rowid: 0` as “read after row zero.” `watch.subscribe` defines an omitted or zero cursor as “start at the current tail”; `-1` explicitly replays from the beginning ([current RPC docs](https://github.com/openclaw/imsg/blob/cdc09c1f2de8d13bf0052f472b810f35048f1557/docs/rpc.md#messagesafter), [watch cursor docs](https://github.com/openclaw/imsg/blob/cdc09c1f2de8d13bf0052f472b810f35048f1557/docs/rpc.md#watchsubscribe)).
+
+Pronto permits an adopted checkpoint at row zero and passes that same zero to both `messages.after` and `watch.subscribe` ([checkpoint adoption](../../packages/messages/src/index.ts#L186-L238), [subscription request](../../packages/messages/src/index.ts#L297-L315)). If the database is empty during catch-up and a row lands before subscribe, the watch's zero-as-tail behavior can skip it. Translate a logical replay-from-start checkpoint to `-1` at the watch boundary, or atomically establish a positive high-water handoff; keep zero for `messages.after`.
+
+The related recovery age policy also needs correction. Pronto applies `maxAgeMs` only during catch-up, and the first old row aborts the entire pass into live-only mode ([catch-up](../../packages/messages/src/index.ts#L745-L825)). That can hide a newer eligible row behind an old one. Skip and advance/tombstone individual stale rows within a bounded scan rather than abandoning all later rows, and add a separate age fence for live notifications in the [`handleNotification`](../../packages/messages/src/index.ts#L472-L518) path. Missing/invalid dates should produce a safe diagnostic, not be treated as fresh.
+
+## Latest-release caution: upstream `main` is already ahead
+
+The latest signed release is v0.15.0, but upstream `main` at `cdc09c1` contains twelve later commits dated September 4. Five groups intersect Pronto directly:
+
+1. [`2d64721`](https://github.com/openclaw/imsg/commit/2d64721d307e80221d1e033938a710e42417b529) preserves watch replay state across unresolved-chat retries and actively drains bounded backlog instead of waiting for another filesystem event or fallback poll.
+2. [`1401843`](https://github.com/openclaw/imsg/commit/1401843c90d23cf76be52e92a854de7f8f0e0dec) makes each physical message appear once across multi-chat joins and preserves explicit-chat context.
+3. [`d39f914`](https://github.com/openclaw/imsg/commit/d39f914f293f66d9b310a032c941e689b74897c0) fixes attributed-body decoding with native length framing, including Unicode, leading line breaks, long text, and malformed input. Pronto's tag activation depends on the decoded `text` field.
+4. [`6b7ca26`](https://github.com/openclaw/imsg/commit/6b7ca263d92af35274e5c916eb57528b980b2cc3) retains subscription ownership until cancellation cleanup completes, reinforcing the documented “no notification after unsubscribe response” contract.
+5. [`cdc09c1`](https://github.com/openclaw/imsg/commit/cdc09c1f2de8d13bf0052f472b810f35048f1557) verifies AppleScript sends against the resolved delivery route, including service and SMS fallback, before returning the GUID that Pronto maps to `confirmed`.
+
+These commits do not prove every bug reproduces through Pronto's exact `chat_id` flow. They do prove the released code was changed immediately afterward in Pronto-critical areas. Do not install untagged `main` on production Macs; wait for a signed/notarized release containing the fixes, or qualify v0.15.0 with targeted regression cases and state the residual risk.
+
+## Should adopt
+
+### Exact direct-chat recovery test
+
+Add a provider contract fixture and owner smoke where an exact direct `chat_id` exists in `chat.db` but is absent from Messages.app's live cache. Verify one text send and one file send stay on the original account/service, never use group recovery, and preserve the existing ambiguous/no-retry result when dispatch cannot be proved. This exercises v0.14.2's main benefit to Pronto.
+
+### Capability and diagnostics snapshot
+
+Pronto correctly gates core behavior on current `status.methods`; keep that. Its public [`MessagesQualification`](../../packages/messages/src/types.ts#L76-L81), however, discards the method list, `supported_methods`, contacts state, and bridge selectors. Retain a sanitized snapshot so optional features can be gated on current readiness and re-probed after child restart. `supported_methods` is only the compiled union; it must never authorize an action.
+
+Pronto currently discards all child stderr with `.resume()` ([RPC spawn](../../packages/messages/src/internal/rpc.ts#L56-L66)). Upstream reserves stderr for diagnostics and documents a benign Contacts-framework message that parents should not misreport ([transport](https://github.com/openclaw/imsg/blob/v0.15.0/docs/rpc.md#transport), [Contacts note](https://github.com/openclaw/imsg/blob/v0.15.0/docs/permissions.md#contacts-optional)). Capture only known/redacted reason codes or a small sanitized ring. Do not persist raw paths, names, handles, or message content.
+
+### Group classification evidence for consumers
+
+Upstream derives `is_group` from whether the chat identifier/GUID contains `;+;`, while `participants` contains external handles only ([group model](https://github.com/openclaw/imsg/blob/v0.15.0/docs/groups.md#what-counts-as-a-group)). Pronto exposes only one `isGroup` boolean in `ConversationFacts`. The standalone Pronto product still requires a tag everywhere, so this does not currently widen its activation policy; library consumers may make different direct/group authorization decisions.
+
+Expose the raw classification evidence or a `direct | group | ambiguous` result. More than one external participant or conflicting chat/message evidence must never be silently downgraded to a permissive direct-chat policy. Keep exact account plus conversation GUID as the route identity.
+
+## Defer
+
+### `send.tracked`
+
+v0.14.2 added caller-owned UUID sends that can be reconciled through `message.send_status`, but they are text-only, require a readable database and the injected IMCore bridge, and never fall back to AppleScript ([contract](https://github.com/openclaw/imsg/blob/v0.15.0/docs/rpc.md#sendtracked)). Pronto's stated default is SIP-on public read/watch/send ([README](../../README.md#requirements)); do not weaken that posture merely to gain reconciliation.
+
+If a separately consented private transport is ever designed, it needs a durable UUID attempt ID, runtime gating on both `send.tracked` and `message.send_status`, post-reconnect reconciliation, and a change to [`ImsgRpcClient`](../../packages/messages/src/internal/rpc.ts#L79-L108), which currently treats only the literal method `send` as submission-uncertain. A missing status row is not authorization to resend. Keep ordinary `send` for SMS/RCS and attachments.
+
+### SSH transport
+
+v0.15.0's SSH contact resolution does not make Pronto remote-compatible. Pronto reads the database path returned by remote RPC and computes the generation with local `realpath` and `stat`, hashing local path/device/inode/birth time ([qualification](../../packages/messages/src/index.ts#L165-L172), [generation identity](../../packages/messages/src/internal/generation.ts#L4-L42)). Remote attachment paths also cannot be materialized as local files. Keep Pronto and `imsg` on the same Mac unless a separate remote-generation token, pinned host identity, and authenticated attachment-staging protocol are designed.
+
+### Bridge-only feature additions
+
+First-contact chat creation, group mutation, poll send/vote, typing, receipts, edit/unsend, and other rich actions require new user authority and effect semantics. Poll creation is specifically multi-effect: `ok: true` may accompany a failed or unknown text caption, and retrying `poll.send` would duplicate the poll ([poll result contract](https://github.com/openclaw/imsg/blob/v0.15.0/docs/rpc.md#polls)). Contact display names must remain presentation-only and never enter authorization.
+
+## Qualification matrix for the next `imsg` target
+
+- Protocol v1 and all current required `status.methods` are present; extra methods do not fail qualification.
+- Headless startup produces no Contacts prompt and no non-JSON stdout.
+- Normal message, attributed-body Unicode message, attachment-only message, reaction, poll row, and URL-preview coalescing preserve one monotonic cursor.
+- An unresolved-chat retry followed by more rows loses nothing; a backlog larger than one watcher batch drains without another filesystem event.
+- Overflow's `resume_after_rowid` plus `messages.after` produces no skipped activation.
+- A row arriving between zero-checkpoint catch-up and watch subscribe is delivered exactly once.
+- Old recovery rows do not hide newer eligible rows; stale live rows never activate.
+- Direct `chat_id` recovery stays on the original account/service for both text and file.
+- `not_started`, `may_have_completed`, `still_in_flight`, `-32000`, and `-32002` map to the intended Pronto result without an unsafe resend.
+- EOF drains an accepted send; forced termination still bounds a hung child.
+- A confirmed reply GUID belongs to the exact resolved chat/service; a missing GUID remains ambiguous.
+- Database replacement invalidates the old generation/cursor; attachment references cannot cross the generation boundary.
+
+## Primary sources
+
+- [`imsg` v0.15.0 release](https://github.com/openclaw/imsg/releases/tag/v0.15.0), [`v0.14.1...v0.15.0`](https://github.com/openclaw/imsg/compare/v0.14.1...v0.15.0), [RPC](https://github.com/openclaw/imsg/blob/v0.15.0/docs/rpc.md), [watch](https://github.com/openclaw/imsg/blob/v0.15.0/docs/watch.md), [send](https://github.com/openclaw/imsg/blob/v0.15.0/docs/send.md), [groups](https://github.com/openclaw/imsg/blob/v0.15.0/docs/groups.md), and [permissions](https://github.com/openclaw/imsg/blob/v0.15.0/docs/permissions.md).
+- [`imsg` current `main` snapshot](https://github.com/openclaw/imsg/tree/cdc09c1f2de8d13bf0052f472b810f35048f1557) and [`v0.15.0...cdc09c1`](https://github.com/openclaw/imsg/compare/v0.15.0...cdc09c1f2de8d13bf0052f472b810f35048f1557).
+- [Pronto v0.2.3 Messages module](https://github.com/eabnelson/pronto/tree/v0.2.3/packages/messages), plus the local files linked throughout this report.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-workspace",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A local iMessage bridge for Codex and Claude Code",
   "type": "module",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-cli",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/messages/README.md
+++ b/packages/messages/README.md
@@ -48,7 +48,7 @@ only when the database identity matches and that exact pre-cutover witness is
 still present; otherwise it returns a structured rejection. An existing Pronto
 checkpoint is always preserved.
 
-The package binds durable checkpoints to a fingerprint of the current Messages database. It restarts and resubscribes after provider failure, performs catch-up within row-count, age, and wall-clock limits, and reports privacy-safe recovery diagnostics. A send that may have reached the provider is returned as `ambiguous` and is never automatically replayed.
+The package binds durable checkpoints to a fingerprint of the current Messages database. It restarts and resubscribes after provider failure, performs catch-up within row-count, age, and wall-clock limits, skips stale recovery rows without hiding newer eligible rows, and rejects stale live notifications. The recovery and live age limits are independently configurable with `recoveryLimits.maxAgeMs` and `recoveryLimits.maxLiveAgeMs`. A send that may have reached the provider is returned as `ambiguous` and is never automatically replayed.
 
 Every observed conversation carries a module-issued, versioned, tamper-evident reference with an expiry. References are process-local by default. A consumer with durable queued work can provide a stable owner-private `referenceKey` of at least 32 bytes; that permits an unexpired observed reference to be revalidated after restart without granting access to a different chat. Rotating the key invalidates outstanding references. History requires that exact reference plus an explicit message, row, byte, and RPC-call budget. Pagination continuations remain bound to the same conversation capability and database generation. They cannot be used to search another conversation.
 
@@ -60,6 +60,11 @@ work can call `resolveConversation` with an already-authorized exact account ID
 and conversation ID; the module performs only an exact bounded lookup and
 returns a fresh scoped reference or `null`. It never exposes catalog browsing or
 fuzzy/global search.
+
+`event.message.destinationCallerId` preserves `imsg`'s message-level
+`destination_caller_id` when present. It is the evidence for the local alias
+used by that specific outbound row; `routing.destinationHandle` remains a
+chat-level routing hint and must not be presented as message-level proof.
 
 Attachment metadata never exposes the Messages source path. Available attachments carry an expiring sealed reference. `materializeAttachment` revalidates the conversation, database generation, provider metadata, containment under the Messages attachments root, regular-file identity, size, and MIME evidence before copying bytes into owner-private scratch. The returned scratch file has an explicit `dispose()` lifecycle.
 

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-imessage",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Reusable local Apple Messages transport for Pronto consumers",
   "type": "module",
   "license": "MIT",

--- a/packages/messages/src/index.ts
+++ b/packages/messages/src/index.ts
@@ -81,6 +81,11 @@ function messageDateMs(value: string | null): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function rawMessageDateMs(value: Record<string, unknown>): number | null {
+  const occurredAt = value.created_at ?? value.date;
+  return typeof occurredAt === "string" ? messageDateMs(occurredAt) : null;
+}
+
 function isMirrorPair(message: MessagesEvent, original: MessagesEvent): boolean {
   if (
     original.conversation.chatId !== message.conversation.chatId ||
@@ -124,7 +129,12 @@ class ProntoMessagesClient implements ProntoMessages {
   readonly #recentOutgoing = new Map<string, MessagesEvent>();
   readonly #inFlightDeliveries = new Map<string, Promise<void>>();
   readonly #state: CheckpointStore;
-  readonly #limits: { readonly maxAgeMs: number; readonly maxDurationMs: number; readonly maxRows: number };
+  readonly #limits: {
+    readonly maxAgeMs: number;
+    readonly maxDurationMs: number;
+    readonly maxLiveAgeMs: number;
+    readonly maxRows: number;
+  };
   #diagnostics: MessagesDiagnostics = {
     attempt: 0,
     catchUpRows: 0,
@@ -139,6 +149,7 @@ class ProntoMessagesClient implements ProntoMessages {
     this.#limits = {
       maxAgeMs: input.recoveryLimits?.maxAgeMs ?? 24 * 60 * 60 * 1_000,
       maxDurationMs: input.recoveryLimits?.maxDurationMs ?? 30_000,
+      maxLiveAgeMs: input.recoveryLimits?.maxLiveAgeMs ?? 5 * 60 * 1_000,
       maxRows: input.recoveryLimits?.maxRows ?? 10_000,
     };
     if (Object.values(this.#limits).some((value) => !Number.isSafeInteger(value) || value <= 0)) {
@@ -305,7 +316,9 @@ class ProntoMessagesClient implements ProntoMessages {
         attachments: true,
         buffer_limit: 256,
         include_reactions: true,
-        ...(checkpoint === undefined ? {} : { since_rowid: checkpoint.rowId }),
+        ...(checkpoint === undefined
+          ? {}
+          : { since_rowid: checkpoint.rowId === 0 ? -1 : checkpoint.rowId }),
       }));
       if (typeof result.subscription !== "number" || !Number.isSafeInteger(result.subscription)) {
         throw new Error("imsg returned an invalid watch subscription");
@@ -504,6 +517,11 @@ class ProntoMessagesClient implements ProntoMessages {
         await recoverUntilSubscribed("database-generation-changed");
         return;
       }
+      const occurredAtMs = rawMessageDateMs(rawMessage);
+      if (occurredAtMs === null || Date.now() - occurredAtMs > this.#limits.maxLiveAgeMs) {
+        await this.#advancePastSuppressed(rawMessage, databaseGeneration);
+        return;
+      }
       try {
         await this.#deliver(rawMessage, databaseGeneration, input);
       } catch (error) {
@@ -579,7 +597,12 @@ class ProntoMessagesClient implements ProntoMessages {
       const data = record(error.data);
       return data.disposition === "may_have_completed" || data.disposition === "still_in_flight"
         ? { status: "ambiguous" }
-        : { retryable: data.retry_safe === true, status: "failed" };
+        : {
+            retryable: data.retry_safe === true ||
+              ((error.code === -32_002 || error.code === -32_003) && data.retryable === true) ||
+              error.code === -32_000,
+            status: "failed",
+          };
     }
   }
 
@@ -788,15 +811,19 @@ class ProntoMessagesClient implements ProntoMessages {
         }
         for (const raw of messages) {
           await this.#assertGeneration(generation, { deadline, rows });
-          const occurredAt = record(raw).created_at ?? record(raw).date;
-          const occurredAtMs = typeof occurredAt === "string" ? Date.parse(occurredAt) : Number.NaN;
-          if (!Number.isFinite(occurredAtMs)) {
+          const rawMessage = record(raw);
+          const occurredAtMs = rawMessageDateMs(rawMessage);
+          if (occurredAtMs === null) {
             throw new RecoveryBoundaryError("invalid-provider-page", rows);
           }
           if (Date.now() - occurredAtMs > this.#limits.maxAgeMs) {
-            throw new RecoveryBoundaryError("age-limit", rows);
+            await this.#withinDeadline(
+              { deadline, rows },
+              async () => await this.#advancePastSuppressed(rawMessage, generation),
+            );
+            rows += 1;
+            continue;
           }
-          const rawMessage = record(raw);
           await this.#deliver(
             rawMessage,
             generation,
@@ -826,6 +853,22 @@ class ProntoMessagesClient implements ProntoMessages {
       }
       throw error;
     }
+  }
+
+  async #advancePastSuppressed(
+    rawMessage: Record<string, unknown>,
+    generation: string,
+  ): Promise<void> {
+    const rowId = rawMessage.id;
+    const providerMessageId = rawMessage.guid;
+    if (
+      typeof rowId !== "number" || !Number.isSafeInteger(rowId) || rowId <= 0 ||
+      typeof providerMessageId !== "string" || providerMessageId === ""
+    ) return;
+    await this.#state.advance(generation, rowId, {
+      providerMessageDigest: this.#providerMessageDigest(providerMessageId),
+      rowId,
+    });
   }
 
   async #isSelfChatMirror(

--- a/packages/messages/src/internal/normalize.ts
+++ b/packages/messages/src/internal/normalize.ts
@@ -64,6 +64,11 @@ function optionalString(value: unknown): string | null {
   return typeof value === "string" && value !== "" ? value : null;
 }
 
+function groupShape(value: string): boolean | null {
+  const marker = /^[^;]+;([+-]);/u.exec(value)?.[1];
+  return marker === "+" ? true : marker === "-" ? false : null;
+}
+
 function attachment(value: unknown): MessagesAttachment | null {
   const raw = record(value);
   if (Object.keys(raw).length === 0) return null;
@@ -94,6 +99,7 @@ export function normalizeConversationFacts(
   const accountLogin = optionalString(chat.account_login);
   const conversationId = optionalString(chat.guid);
   const destinationHandle = optionalString(chat.last_addressed_handle);
+  const shapedAsGroup = conversationId === null ? null : groupShape(conversationId);
   const participants = Array.isArray(message.participants) &&
       message.participants.every((value) => typeof value === "string" && value !== "")
     ? [...new Set(message.participants)] as string[]
@@ -111,6 +117,7 @@ export function normalizeConversationFacts(
     destinationHandle === null || chat.id !== chatId ||
     message.chat_id !== chatId || message.chat_guid !== conversationId ||
     typeof message.is_group !== "boolean" || chat.is_group !== message.is_group ||
+    shapedAsGroup === null || shapedAsGroup !== message.is_group ||
     participants === null || (message.is_group && participants.length === 0)
   ) return base;
   return {
@@ -160,6 +167,7 @@ export function normalizeEvent(
           return normalized === null ? [] : [normalized];
         })
         : [],
+      destinationCallerId: optionalString(raw.destination_caller_id),
       fromMe: raw.is_from_me === true,
       kind: Object.keys(reaction).length > 0 || raw.is_reaction === true
         ? "reaction"

--- a/packages/messages/src/internal/rpc.ts
+++ b/packages/messages/src/internal/rpc.ts
@@ -47,13 +47,25 @@ export class ImsgRpcClient implements RpcConnection {
   readonly #handlers = new Set<(notification: RpcNotification) => void>();
   readonly #failureHandlers = new Set<(reason: string) => void>();
   readonly #pending = new Map<string, PendingRequest>();
+  readonly #idleShutdownGraceMs: number;
+  readonly #shutdownGraceMs: number;
+  readonly #terminationGraceMs: number;
   #buffer = "";
+  #closePromise: Promise<void> | undefined;
   #closed = false;
   #failed = false;
   #nextId = 1;
   #resolveTerminated!: () => void;
 
-  constructor(command: string) {
+  constructor(command: string, options: {
+    readonly idleShutdownGraceMs?: number;
+    readonly shutdownGraceMs?: number;
+    readonly terminationGraceMs?: number;
+  } = {}) {
+    this.#shutdownGraceMs = options.shutdownGraceMs ?? 5_000;
+    this.#idleShutdownGraceMs = options.idleShutdownGraceMs ??
+      Math.min(250, this.#shutdownGraceMs);
+    this.#terminationGraceMs = options.terminationGraceMs ?? 2_000;
     this.#child = spawn(command, ["rpc"], { stdio: ["pipe", "pipe", "pipe"] });
     this.#child.stderr.resume();
     this.terminated = new Promise((resolve) => {
@@ -61,7 +73,7 @@ export class ImsgRpcClient implements RpcConnection {
     });
     this.#child.stdout.on("data", (chunk: Buffer | string) => this.#onData(chunk));
     this.#child.once("error", (error) => this.#fail("spawn-error", error));
-    this.#child.once("exit", () => {
+    this.#child.once("close", () => {
       this.#fail("process-exit", new Error("imsg RPC process exited"));
     });
   }
@@ -110,11 +122,37 @@ export class ImsgRpcClient implements RpcConnection {
   }
 
   async close(): Promise<void> {
-    if (this.#closed) return;
+    if (this.#closePromise !== undefined) return await this.#closePromise;
     this.#closed = true;
+    this.#closePromise = this.#shutdown();
+    await this.#closePromise;
+  }
+
+  async #shutdown(): Promise<void> {
     this.#child.stdin.end();
+    const graceMs = this.#pending.size === 0
+      ? this.#idleShutdownGraceMs
+      : this.#shutdownGraceMs;
+    if (await this.#waitForTermination(graceMs)) return;
     this.#child.kill("SIGTERM");
+    if (await this.#waitForTermination(this.#terminationGraceMs)) return;
+    this.#child.kill("SIGKILL");
     await this.terminated;
+  }
+
+  async #waitForTermination(milliseconds: number): Promise<boolean> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        this.terminated.then(() => true),
+        new Promise<false>((resolve) => {
+          timer = setTimeout(() => resolve(false), milliseconds);
+          timer.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
   }
 
   #onData(chunk: Buffer | string): void {

--- a/packages/messages/src/types.ts
+++ b/packages/messages/src/types.ts
@@ -46,6 +46,7 @@ export interface MessagesEvent {
   readonly conversationFacts: ConversationFacts;
   readonly message: {
     readonly attachments: readonly MessagesAttachment[];
+    readonly destinationCallerId: string | null;
     readonly fromMe: boolean;
     readonly kind: "message" | "poll" | "reaction";
     readonly occurredAt: string | null;
@@ -126,6 +127,7 @@ export interface MessagesDiagnostics {
 }
 
 export interface MessagesRecoveryLimits {
+  readonly maxLiveAgeMs?: number;
   readonly maxAgeMs?: number;
   readonly maxDurationMs?: number;
   readonly maxRows?: number;

--- a/packages/messages/test/public-interface.test.ts
+++ b/packages/messages/test/public-interface.test.ts
@@ -13,11 +13,19 @@ afterEach(async () => {
 });
 
 interface TranscriptScenario {
+  readonly chatGuid?: string;
+  readonly chatIsGroup?: boolean;
   readonly event: Record<string, unknown>;
   readonly expectedFilePath?: string;
   readonly exitDuringSend?: boolean;
   readonly nearby?: readonly Record<string, unknown>[];
+  readonly providerVersion?: string;
   readonly replaceDatabaseDuringHistory?: boolean;
+  readonly sendError?: {
+    readonly code: number;
+    readonly data?: Record<string, unknown>;
+    readonly message: string;
+  };
   readonly sentMessages: number;
 }
 
@@ -44,7 +52,7 @@ for await (const chunk of Bun.stdin.stream()) {
     if (request.method === "initialize") {
       result = {
         protocol_version: 1,
-        version: "0.14.1",
+        version: scenario.providerVersion ?? "0.14.1",
         database: { path: scenario.databasePath, ready: true, features: { routing_metadata: true } },
         methods: ["initialize", "status", "chats.list", "messages.history", "messages.after", "messages.stats", "watch.subscribe", "watch.unsubscribe", "send"],
       };
@@ -55,9 +63,9 @@ for await (const chunk of Bun.stdin.stream()) {
         chats: [{
           account_id: "E:owner@example.com",
           account_login: "owner@example.com",
-          guid: "iMessage;-;+15550000000",
+          guid: scenario.chatGuid ?? "iMessage;-;+15550000000",
           id: 42,
-          is_group: false,
+          is_group: scenario.chatIsGroup ?? false,
           last_addressed_handle: "+15551111111",
           service: "iMessage",
         }],
@@ -84,6 +92,14 @@ for await (const chunk of Bun.stdin.stream()) {
         throw new Error("reply attachment was not preserved");
       }
       if (scenario.exitDuringSend === true) process.exit(0);
+      if (scenario.sendError !== undefined) {
+        process.stdout.write(JSON.stringify({
+          jsonrpc: "2.0",
+          id: request.id,
+          error: scenario.sendError,
+        }) + "\\n");
+        continue;
+      }
       result = { ok: true, guid: "outbound-guid" };
     } else {
       result = { ok: true };
@@ -100,7 +116,10 @@ for await (const chunk of Bun.stdin.stream()) {
 }
 `, { mode: 0o700 });
   await chmod(transcript, 0o700);
-  return createProntoMessages({ imsgPath: transcript });
+  return createProntoMessages({
+    imsgPath: transcript,
+    recoveryLimits: { maxLiveAgeMs: Number.MAX_SAFE_INTEGER },
+  });
 }
 
 async function nextEvent(messages: ProntoMessages): Promise<MessagesEvent> {
@@ -122,16 +141,21 @@ const inboundEvent = {
   is_from_me: false,
   is_group: false,
   chat_guid: "iMessage;-;+15550000000",
+  destination_caller_id: "+15551111111",
   participants: ["+15550000000", "+15551111111"],
   sender: "+15550000000",
   service: "iMessage",
   text: "hello from Messages",
 };
 
-test("normalizes one inbound transcript event and replies to its exact conversation", async () => {
-  const messages = await transcriptClient({ event: inboundEvent, sentMessages: 3 });
+test("normalizes one imsg 0.15 transcript event and replies to its exact conversation", async () => {
+  const messages = await transcriptClient({
+    event: inboundEvent,
+    providerVersion: "0.15.0",
+    sentMessages: 3,
+  });
   const qualification = await messages.qualify();
-  expect(qualification).toMatchObject({ providerVersion: "0.14.1", status: "ready" });
+  expect(qualification).toMatchObject({ providerVersion: "0.15.0", status: "ready" });
 
   const event = await nextEvent(messages);
   expect(event).toEqual({
@@ -157,6 +181,7 @@ test("normalizes one inbound transcript event and replies to its exact conversat
     },
     message: {
       attachments: [],
+      destinationCallerId: "+15551111111",
       fromMe: false,
       kind: "message",
       occurredAt: "2026-09-01T12:00:00.000Z",
@@ -232,6 +257,22 @@ test("reports owner-absent conversations as normalized provider facts", async ()
   await messages.close();
 });
 
+test("withholds routing when the conversation GUID contradicts group flags", async () => {
+  const groupShapedGuid = "iMessage;+;chat123456789";
+  const messages = await transcriptClient({
+    chatGuid: groupShapedGuid,
+    chatIsGroup: false,
+    event: {
+      ...inboundEvent,
+      chat_guid: groupShapedGuid,
+      is_group: false,
+    },
+    sentMessages: 1,
+  });
+  expect((await nextEvent(messages)).conversationFacts.routing).toBeUndefined();
+  await messages.close();
+});
+
 test("marks a provider mirror by correlating nearby outbound history", async () => {
   const messages = await transcriptClient({
     event: {
@@ -264,4 +305,38 @@ test("classifies a process failure after send submission as ambiguous without re
     text: "one external effect",
   })).toEqual({ status: "ambiguous" });
   await messages.close();
+});
+
+test("preserves provider retryability without treating uncertain sends as retryable", async () => {
+  const availabilityFailure = await transcriptClient({
+    event: inboundEvent,
+    sendError: {
+      code: -32_002,
+      data: { retryable: true },
+      message: "Messages database is unavailable",
+    },
+    sentMessages: 1,
+  });
+  const availabilityEvent = await nextEvent(availabilityFailure);
+  expect(await availabilityFailure.reply({
+    conversation: availabilityEvent.conversation,
+    text: "retry after recovery",
+  })).toEqual({ retryable: true, status: "failed" });
+  await availabilityFailure.close();
+
+  const uncertainFailure = await transcriptClient({
+    event: inboundEvent,
+    sendError: {
+      code: -32_004,
+      data: { disposition: "may_have_completed", retry_safe: false },
+      message: "delivery could not be verified",
+    },
+    sentMessages: 1,
+  });
+  const uncertainEvent = await nextEvent(uncertainFailure);
+  expect(await uncertainFailure.reply({
+    conversation: uncertainEvent.conversation,
+    text: "do not replay",
+  })).toEqual({ status: "ambiguous" });
+  await uncertainFailure.close();
 });

--- a/packages/messages/test/recovery.test.ts
+++ b/packages/messages/test/recovery.test.ts
@@ -53,7 +53,7 @@ function checkpointWitness(rowId = 40, providerMessageId = "checkpoint-guid") {
   };
 }
 
-test("reports bounded age recovery and resumes with live events only", async () => {
+test("skips stale recovery rows without hiding newer eligible rows", async () => {
   const directory = await fixtureDirectory();
   const databasePath = join(directory, "chat.db");
   const statePath = join(directory, "provider-state.json");
@@ -64,6 +64,7 @@ test("reports bounded age recovery and resumes with live events only", async () 
     checkpointWitness(),
   );
   const oldDate = new Date(Date.now() - 25 * 60 * 60 * 1_000).toISOString();
+  const recentDate = new Date().toISOString();
   const executable = await executableWithSource(directory, rpcLoop(`
     let result;
     if (request.method === "initialize") result = {
@@ -79,29 +80,116 @@ test("reports bounded age recovery and resumes with live events only", async () 
     };
     else if (request.method === "messages.after") result = {
       has_more: false,
-      messages: [{ chat_id: 42, created_at: ${JSON.stringify(oldDate)}, guid: "old-guid", id: 41, is_from_me: false, service: "iMessage", text: "old" }],
-      next_rowid: 41,
+      messages: [
+        { chat_id: 42, created_at: ${JSON.stringify(oldDate)}, guid: "old-guid", id: 41, is_from_me: false, service: "iMessage", text: "old" },
+        { chat_id: 42, created_at: ${JSON.stringify(recentDate)}, guid: "new-guid", id: 42, is_from_me: false, service: "iMessage", text: "new" },
+      ],
+      next_rowid: 42,
     };
+    else if (request.method === "messages.stats") result = { chats: [{ chat_id: 42, service: "iMessage" }], sent_messages: 1 };
     else if (request.method === "watch.subscribe") result = { subscription: 8 };
     else result = { ok: true };
     process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: request.id, result }) + "\\n");
   `));
   const messages = createProntoMessages({ imsgPath: executable, statePath });
   const outcomes: MessagesRecoveryOutcome[] = [];
+  const delivered: number[] = [];
 
   const subscription = await messages.subscribe({
-    onEvent: () => {
-      throw new Error("old recovery event must not be delivered");
-    },
+    onEvent: (event) => { delivered.push(event.message.rowId); },
     onRecovery: (outcome) => { outcomes.push(outcome); },
   });
-  expect(outcomes).toEqual([{
-    action: "live-events-only",
-    reason: "age-limit",
-    rows: 0,
-    status: "degraded",
-  }]);
-  expect(messages.diagnostics()).toMatchObject({ recoveryReason: "age-limit", state: "degraded" });
+  expect(delivered).toEqual([42]);
+  expect(outcomes).toEqual([{ rows: 2, status: "recovered" }]);
+  expect(messages.diagnostics()).toMatchObject({ catchUpRows: 2, state: "ready" });
+  await subscription.close();
+  await messages.close();
+});
+
+test("suppresses a stale live notification and advances its checkpoint", async () => {
+  const directory = await fixtureDirectory();
+  const databasePath = join(directory, "chat.db");
+  const statePath = join(directory, "provider-state.json");
+  await writeFile(databasePath, "database evidence");
+  const oldDate = new Date(Date.now() - 10 * 60 * 1_000).toISOString();
+  const executable = await executableWithSource(directory, rpcLoop(`
+    let result;
+    if (request.method === "initialize") result = {
+      protocol_version: 1,
+      version: "0.15.0",
+      database: { path: ${JSON.stringify(databasePath)}, ready: true, features: { routing_metadata: true } },
+      methods: ["initialize", "status", "chats.list", "messages.history", "messages.after", "messages.stats", "watch.subscribe", "watch.unsubscribe", "send"],
+    };
+    else if (request.method === "watch.subscribe") result = { subscription: 18 };
+    else result = { ok: true };
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: request.id, result }) + "\\n");
+    if (request.method === "watch.subscribe") {
+      process.stdout.write(JSON.stringify({
+        jsonrpc: "2.0",
+        method: "message",
+        params: {
+          subscription: 18,
+          message: { chat_id: 42, created_at: ${JSON.stringify(oldDate)}, guid: "stale-live-guid", id: 1, is_from_me: false, service: "iMessage", text: "stale" },
+        },
+      }) + "\\n");
+    }
+  `));
+  const messages = createProntoMessages({ imsgPath: executable, statePath });
+  const delivered: number[] = [];
+  const subscription = await messages.subscribe({
+    onEvent: (event) => { delivered.push(event.message.rowId); },
+  });
+  const generation = await databaseGeneration(databasePath);
+  const deadline = Date.now() + 2_000;
+  let checkpoint = await new ProviderStateStore(statePath).checkpoint(generation);
+  while (checkpoint?.rowId !== 1 && Date.now() < deadline) {
+    await Bun.sleep(20);
+    checkpoint = await new ProviderStateStore(statePath).checkpoint(generation);
+  }
+  expect(delivered).toEqual([]);
+  expect(checkpoint?.rowId).toBe(1);
+  await subscription.close();
+  await messages.close();
+});
+
+test("uses the watch replay sentinel for an adopted zero checkpoint", async () => {
+  const directory = await fixtureDirectory();
+  const databasePath = join(directory, "chat.db");
+  const requestLog = join(directory, "requests.log");
+  const statePath = join(directory, "provider-state.json");
+  await writeFile(databasePath, "database evidence");
+  const generation = await databaseGeneration(databasePath);
+  await new ProviderStateStore(statePath).initialize(generation, 0);
+  const executable = await executableWithSource(directory, `
+import { appendFileSync } from "node:fs";
+${rpcLoop(`
+    appendFileSync(${JSON.stringify(requestLog)}, JSON.stringify(request) + "\\n");
+    let result;
+    if (request.method === "initialize") result = {
+      protocol_version: 1,
+      version: "0.15.0",
+      database: { path: ${JSON.stringify(databasePath)}, ready: true, features: { routing_metadata: true } },
+      methods: ["initialize", "status", "chats.list", "messages.history", "messages.after", "messages.stats", "watch.subscribe", "watch.unsubscribe", "send"],
+    };
+    else if (request.method === "messages.after") result = {
+      has_more: false,
+      messages: [],
+      next_rowid: Number(request.params.since_rowid),
+    };
+    else if (request.method === "watch.subscribe") result = { subscription: 19 };
+    else result = { ok: true };
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: request.id, result }) + "\\n");
+  `)}
+  `);
+  const messages = createProntoMessages({ imsgPath: executable, statePath });
+  const subscription = await messages.subscribe({ onEvent: () => undefined });
+  const requests = (await readFile(requestLog, "utf8")).trim().split("\n")
+    .map((line) => JSON.parse(line));
+  const history = requests.find((request) => request.method === "messages.after" &&
+    request.params.since_rowid === 0);
+  const watch = requests.find((request) => request.method === "watch.subscribe");
+  expect(history).toBeDefined();
+  expect(watch.params.since_rowid).toBe(-1);
   await subscription.close();
   await messages.close();
 });

--- a/packages/messages/test/rpc-recovery.test.ts
+++ b/packages/messages/test/rpc-recovery.test.ts
@@ -1,9 +1,30 @@
-import { expect, test } from "bun:test";
+import { afterEach, expect, test } from "bun:test";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
+  ImsgRpcClient,
   ResilientRpcClient,
   type RpcConnection,
   type RpcNotification,
 } from "../src/internal/rpc";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((path) => rm(path, { force: true, recursive: true })),
+  );
+});
+
+async function executable(source: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "pronto-rpc-lifecycle-"));
+  temporaryDirectories.push(directory);
+  const path = join(directory, "imsg-fixture");
+  await writeFile(path, `#!/usr/bin/env bun\n${source}`, { mode: 0o700 });
+  await chmod(path, 0o700);
+  return path;
+}
 
 class FakeConnection implements RpcConnection {
   readonly methods: string[] = [];
@@ -66,4 +87,50 @@ test("restarts the provider but never replays an already submitted send", async 
     state: "ready",
   });
   await rpc.close();
+});
+
+test("drains an accepted request before closing the provider", async () => {
+  const command = await executable(`
+const decoder = new TextDecoder();
+let buffer = "";
+for await (const chunk of Bun.stdin.stream()) {
+  buffer += decoder.decode(chunk, { stream: true });
+  while (buffer.includes("\\n")) {
+    const newline = buffer.indexOf("\\n");
+    const line = buffer.slice(0, newline);
+    buffer = buffer.slice(newline + 1);
+    if (line.trim() === "") continue;
+    const request = JSON.parse(line);
+    await Bun.sleep(50);
+    process.stdout.write(JSON.stringify({
+      jsonrpc: "2.0",
+      id: request.id,
+      result: { ok: true, guid: "drained-guid" },
+    }) + "\\n");
+  }
+}
+`);
+  const rpc = new ImsgRpcClient(command, {
+    shutdownGraceMs: 1_000,
+    terminationGraceMs: 100,
+  });
+  const request = rpc.request("send", { chat_id: 42, text: "drain me" });
+  const close = rpc.close();
+  await expect(request).resolves.toEqual({ ok: true, guid: "drained-guid" });
+  await close;
+});
+
+test("force-terminates a provider that does not exit after EOF", async () => {
+  const command = await executable(`
+process.on("SIGTERM", () => undefined);
+process.stdin.resume();
+setInterval(() => undefined, 1_000);
+`);
+  const rpc = new ImsgRpcClient(command, {
+    shutdownGraceMs: 50,
+    terminationGraceMs: 50,
+  });
+  const startedAt = Date.now();
+  await rpc.close();
+  expect(Date.now() - startedAt).toBeLessThan(1_000);
 });

--- a/packages/messages/test/scoped-access.test.ts
+++ b/packages/messages/test/scoped-access.test.ts
@@ -101,6 +101,7 @@ for await (const chunk of Bun.stdin.stream()) {
   return createProntoMessages({
     ...(input.attachmentsRoot === undefined ? {} : { attachmentsRoot: input.attachmentsRoot }),
     imsgPath: executable,
+    recoveryLimits: { maxLiveAgeMs: Number.MAX_SAFE_INTEGER },
     ...(input.referenceKey === undefined ? {} : { referenceKey: input.referenceKey }),
     scopeLimits: {
       maxAttachmentBytes: 1_024 * 1_024,

--- a/test/unit/activation.test.ts
+++ b/test/unit/activation.test.ts
@@ -28,6 +28,7 @@ function event(overrides: {
     },
     message: {
       attachments: [],
+      destinationCallerId: null,
       fromMe: overrides.fromMe ?? false,
       kind: overrides.kind ?? "message",
       occurredAt: "2026-09-01T12:00:00.000Z",

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -36,7 +36,7 @@ describe("Pronto CLI", () => {
     ]);
 
     expect(exitCode).toBe(0);
-    expect(stdout.trim()).toBe("pronto 0.2.3");
+    expect(stdout.trim()).toBe("pronto 0.2.4");
   });
 
   test("the legacy command explains the rename and delegates safe commands", async () => {
@@ -54,7 +54,7 @@ describe("Pronto CLI", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr.trim()).toBe("s4imsg is now Pronto; use the pronto command.");
-    expect(stdout.trim()).toBe("pronto 0.2.3");
+    expect(stdout.trim()).toBe("pronto 0.2.4");
   });
 
   test("the legacy command refuses to start a second foreground listener", async () => {

--- a/test/unit/current-chat-source.test.ts
+++ b/test/unit/current-chat-source.test.ts
@@ -34,6 +34,7 @@ const event: MessagesEvent = {
       reference: attachment,
       sizeBytes: 12,
     }],
+    destinationCallerId: null,
     fromMe: false,
     kind: "message",
     occurredAt: "2026-09-01T12:00:00.000Z",

--- a/test/unit/imsg-transport.test.ts
+++ b/test/unit/imsg-transport.test.ts
@@ -26,6 +26,7 @@ function event(overrides: {
     conversationFacts: { ownerParticipated: true, service: "iMessage" },
     message: {
       attachments: [],
+      destinationCallerId: null,
       fromMe: overrides.fromMe ?? false,
       kind: "message",
       occurredAt: "2026-09-01T12:00:00.000Z",


### PR DESCRIPTION
## Summary
- qualify `pronto-imessage` 0.2.4 against `imsg` 0.15.0 while preserving the public RPC-v1 capability contract
- drain accepted RPC work on shutdown and preserve upstream retryability without replaying uncertain sends
- fence stale live/recovery rows, repair zero-cursor watch handoff, preserve message-level destination identity, and fail closed on contradictory group metadata
- add the upstream compatibility audit and focused regression coverage

## Verification
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun test` (238 passing)
- `bun run build`
- `bun run release:validate`
- exact signed `imsg` 0.15.0 local qualification: ready, no degraded capabilities

The v0.2.4 release remains gated on the required owner-run live Messages smoke before tagging or npm publication.