### PR TITLE
Add secure automatic updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,20 +5,19 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
-    inputs:
-      release_tag:
-        description: Existing immutable tag to rebuild and publish
-        required: true
-        type: string
 
 permissions:
   contents: read
 
 jobs:
   build:
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-15
+    environment: release
     env:
-      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+      RELEASE_TAG: ${{ github.ref_name }}
+      PRONTO_SIGNING_IDENTIFIER: dev.pronto.cli
+      PRONTO_SIGNING_TEAM_IDENTIFIER: 9YCNUWK84C
     permissions:
       contents: read
     outputs:
@@ -30,10 +29,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
-      - name: Verify recovery checkout is the immutable tag
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: test "$(git rev-parse HEAD)" = "$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")"
+          ref: ${{ github.ref }}
+          fetch-depth: 0
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
@@ -43,22 +40,25 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run typecheck
       - run: bun run build
-      - run: codesign --verify --strict --verbose=4 dist/pronto
       - run: bun test
       - run: ./dist/pronto --version
       - run: ./dist/pronto --help
       - run: node --input-type=module --eval 'import("./packages/messages/dist/index.js").then((module) => { if (typeof module.createProntoMessages !== "function") process.exit(1); })'
       - run: bun run release:validate
-      - name: Verify tag matches package version
+      - name: Verify immutable tag and package version
         id: release-version
         run: |
           VERSION="$(bun -e 'import packageJson from "./package.json" with { type: "json" }; process.stdout.write(packageJson.version)')"
           PACKAGE_VERSION="$(bun -e 'import packageJson from "./packages/messages/package.json" with { type: "json" }; process.stdout.write(packageJson.version)')"
+          test "$GITHUB_REF_TYPE" = "tag"
           test "v$VERSION" = "$RELEASE_TAG"
           test "$VERSION" = "$PACKAGE_VERSION"
-          echo "package-file=pronto-imessage-$PACKAGE_VERSION.tgz" >> "$GITHUB_OUTPUT"
-          echo "package-version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "release-tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          test "$(git rev-parse HEAD)" = "$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")"
+          {
+            echo "package-file=pronto-imessage-$PACKAGE_VERSION.tgz"
+            echo "package-version=$PACKAGE_VERSION"
+            echo "release-tag=$RELEASE_TAG"
+          } >> "$GITHUB_OUTPUT"
           if [[ "$VERSION" == *-* ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
@@ -66,29 +66,124 @@ jobs:
           fi
       - name: Verify owner qualification is complete
         run: bun ./scripts/release-qualification.ts docs/RELEASE_QUALIFICATION.md "$RELEASE_TAG"
-      - name: Create and verify checksum
+      - name: Build native release artifacts
+        env:
+          PRONTO_RELEASE_VERSION: ${{ steps.release-version.outputs.package-version }}
         run: |
-          npm pack ./packages/messages --pack-destination ./dist
-          test -f "dist/${{ steps.release-version.outputs.package-file }}"
-          cd dist
-          shasum -a 256 pronto > pronto.sha256
+          mkdir -p release
+          bun build packages/cli/src/cli.ts --compile --target=bun-darwin-arm64 \
+            --outfile release/pronto-darwin-arm64
+          bun build packages/cli/src/cli.ts --compile --target=bun-darwin-x64 \
+            --outfile release/pronto-darwin-x64
+      - name: Import release credentials
+        env:
+          PRONTO_DEVELOPER_ID_P12_B64: ${{ secrets.PRONTO_DEVELOPER_ID_P12_B64 }}
+          PRONTO_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.PRONTO_DEVELOPER_ID_P12_PASSWORD }}
+          PRONTO_NOTARY_KEY_P8_B64: ${{ secrets.PRONTO_NOTARY_KEY_P8_B64 }}
+        run: |
+          test -n "$PRONTO_DEVELOPER_ID_P12_B64"
+          test -n "$PRONTO_DEVELOPER_ID_P12_PASSWORD"
+          test -n "$PRONTO_NOTARY_KEY_P8_B64"
+          certificate="$RUNNER_TEMP/pronto-developer-id.p12"
+          notary_key="$RUNNER_TEMP/pronto-notary-key.p8"
+          keychain="$RUNNER_TEMP/pronto-signing.keychain-db"
+          keychain_password="$(openssl rand -hex 32)"
+          printf '%s' "$PRONTO_DEVELOPER_ID_P12_B64" | base64 -D > "$certificate"
+          printf '%s' "$PRONTO_NOTARY_KEY_P8_B64" | base64 -D > "$notary_key"
+          chmod 600 "$certificate" "$notary_key"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$certificate" -P "$PRONTO_DEVELOPER_ID_P12_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$keychain"
+          security set-key-partition-list -S apple-tool:,apple: -s \
+            -k "$keychain_password" "$keychain"
+          security list-keychains -d user -s "$keychain"
+          echo "PRONTO_SIGNING_KEYCHAIN=$keychain" >> "$GITHUB_ENV"
+          echo "PRONTO_NOTARY_KEY_PATH=$notary_key" >> "$GITHUB_ENV"
+      - name: Sign and notarize native release artifacts
+        env:
+          PRONTO_NOTARY_KEY_ID: ${{ secrets.PRONTO_NOTARY_KEY_ID }}
+          PRONTO_NOTARY_ISSUER_ID: ${{ secrets.PRONTO_NOTARY_ISSUER_ID }}
+        run: |
+          test -n "$PRONTO_NOTARY_KEY_ID"
+          test -n "$PRONTO_NOTARY_ISSUER_ID"
+          identity="$(security find-identity -v -p codesigning "$PRONTO_SIGNING_KEYCHAIN" | awk '/Developer ID Application:/ { print $2; exit }')"
+          test -n "$identity" || { echo "Developer ID Application identity unavailable" >&2; exit 1; }
+          requirement="identifier \"$PRONTO_SIGNING_IDENTIFIER\" and anchor apple generic and certificate leaf[subject.OU] = \"$PRONTO_SIGNING_TEAM_IDENTIFIER\""
+          for asset in pronto-darwin-arm64 pronto-darwin-x64; do
+            codesign --force --options runtime --timestamp \
+              --identifier "$PRONTO_SIGNING_IDENTIFIER" \
+              --keychain "$PRONTO_SIGNING_KEYCHAIN" \
+              --sign "$identity" "release/$asset"
+            codesign --verify --strict --verbose=4 -R="$requirement" "release/$asset"
+            signing_info="$(codesign -dv --verbose=4 "release/$asset" 2>&1)"
+            test "$(sed -n 's/^Identifier=//p' <<< "$signing_info")" = "$PRONTO_SIGNING_IDENTIFIER"
+            test "$(sed -n 's/^TeamIdentifier=//p' <<< "$signing_info")" = "$PRONTO_SIGNING_TEAM_IDENTIFIER"
+            grep -q '^flags=.*runtime' <<< "$signing_info"
+            grep -q '^Timestamp=' <<< "$signing_info"
+            archive="$RUNNER_TEMP/$asset.zip"
+            ditto -c -k --keepParent "release/$asset" "$archive"
+            notarization="$(xcrun notarytool submit "$archive" \
+              --issuer "$PRONTO_NOTARY_ISSUER_ID" \
+              --key-id "$PRONTO_NOTARY_KEY_ID" \
+              --key "$PRONTO_NOTARY_KEY_PATH" \
+              --wait --output-format json)"
+            test "$(jq -r '.status' <<< "$notarization")" = "Accepted"
+            submission_id="$(jq -r '.id' <<< "$notarization")"
+            xcrun notarytool log "$submission_id" \
+              --issuer "$PRONTO_NOTARY_ISSUER_ID" \
+              --key-id "$PRONTO_NOTARY_KEY_ID" \
+              --key "$PRONTO_NOTARY_KEY_PATH" > "$RUNNER_TEMP/$asset-notary-log.json"
+            test "$(jq -r '.status' "$RUNNER_TEMP/$asset-notary-log.json")" = "Accepted"
+          done
+      - name: Smoke test signed release artifacts
+        env:
+          PRONTO_RELEASE_VERSION: ${{ steps.release-version.outputs.package-version }}
+        run: |
+          test "$(arch -arm64 ./release/pronto-darwin-arm64 --version)" = "pronto $PRONTO_RELEASE_VERSION"
+          test "$(arch -x86_64 ./release/pronto-darwin-x64 --version)" = "pronto $PRONTO_RELEASE_VERSION"
+      - name: Create signed update manifest and checksums
+        env:
+          PRONTO_RELEASE_DIRECTORY: release
+          PRONTO_RELEASE_VERSION: ${{ steps.release-version.outputs.package-version }}
+          PRONTO_RELEASE_REVISION: ${{ github.sha }}
+          PRONTO_RELEASE_ED25519_PRIVATE_KEY: ${{ secrets.PRONTO_RELEASE_ED25519_PRIVATE_KEY }}
+        run: |
+          PRONTO_RELEASE_PUBLISHED_AT="$(date -u +'%Y-%m-%dT%H:%M:%S.000Z')"
+          export PRONTO_RELEASE_PUBLISHED_AT
+          bun scripts/generate-update-manifest.ts
+          npm pack ./packages/messages --pack-destination ./release
+          cd release
+          shasum -a 256 pronto-darwin-arm64 pronto-darwin-x64 pronto-update.json > pronto.sha256
           shasum -a 256 -c pronto.sha256
           shasum -a 256 "${{ steps.release-version.outputs.package-file }}" > pronto-imessage.sha256
           shasum -a 256 -c pronto-imessage.sha256
+      - name: Remove temporary signing material
+        if: always()
+        run: |
+          keychain="$RUNNER_TEMP/pronto-signing.keychain-db"
+          security delete-keychain "$keychain" >/dev/null 2>&1 || true
+          find "$RUNNER_TEMP" -maxdepth 1 -type f \
+            \( -name 'pronto-developer-id.p12' -o -name 'pronto-notary-key.p8' -o -name 'pronto-*-notary-log.json' -o -name 'pronto-darwin-*.zip' \) \
+            -delete
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: pronto-macos
+          name: pronto-release
           retention-days: 1
           path: |
-            dist/pronto
-            dist/pronto.sha256
-            dist/pronto-imessage-*.tgz
-            dist/pronto-imessage.sha256
+            release/pronto-darwin-arm64
+            release/pronto-darwin-x64
+            release/pronto-update.json
+            release/pronto.sha256
+            release/pronto-imessage-*.tgz
+            release/pronto-imessage.sha256
 
   publish:
     needs: build
     runs-on: ubuntu-latest
     permissions:
+      attestations: write
       contents: write
       id-token: write
     env:
@@ -113,7 +208,7 @@ jobs:
           fi
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: pronto-macos
+          name: pronto-release
           path: release-assets
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -125,11 +220,19 @@ jobs:
         run: |
           test "$(node --version)" = "v22.23.1"
           test "$(npm --version)" = "11.19.1"
-      - name: Verify downloaded checksum
+      - name: Verify downloaded checksums
         working-directory: release-assets
         run: |
           sha256sum -c pronto.sha256
           sha256sum -c pronto-imessage.sha256
+      - name: Attest release artifacts
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-path: |
+            release-assets/pronto-darwin-arm64
+            release-assets/pronto-darwin-x64
+            release-assets/pronto-update.json
+            release-assets/${{ needs.build.outputs.package-file }}
       - name: Create draft release
         run: |
           gh release create "$RELEASE_TAG" --draft --generate-notes --verify-tag \
@@ -137,9 +240,9 @@ jobs:
       - name: Upload and verify draft assets
         run: |
           gh release upload "$RELEASE_TAG" \
-            release-assets/pronto release-assets/pronto.sha256 \
+            release-assets/pronto-darwin-arm64 release-assets/pronto-darwin-x64 \
+            release-assets/pronto-update.json release-assets/pronto.sha256 \
             "release-assets/$PACKAGE_FILE" release-assets/pronto-imessage.sha256
-
           RELEASE_ID="$(
             gh api --paginate "repos/$GH_REPO/releases?per_page=100" |
               jq -r --arg tag "$RELEASE_TAG" --arg package "$PACKAGE_FILE" '
@@ -147,7 +250,14 @@ jobs:
                 select(
                   .tag_name == $tag and
                   .draft == true and
-                  ([.assets[].name] | sort) == (["pronto", "pronto.sha256", "pronto-imessage.sha256", $package] | sort)
+                  ([.assets[].name] | sort) == ([
+                    "pronto-darwin-arm64",
+                    "pronto-darwin-x64",
+                    "pronto-update.json",
+                    "pronto.sha256",
+                    "pronto-imessage.sha256",
+                    $package
+                  ] | sort)
                 ) |
                 .id
               '
@@ -166,6 +276,7 @@ jobs:
           for ATTEMPT in {1..60}; do
             REMOTE_VERSION="$(npm view "pronto-imessage@$PACKAGE_VERSION" version 2>/dev/null || true)"
             [[ "$REMOTE_VERSION" = "$PACKAGE_VERSION" ]] && break
+            echo "Waiting for npm registry propagation (attempt $ATTEMPT/60)."
             sleep 5
           done
           test "$REMOTE_VERSION" = "$PACKAGE_VERSION"

--- a/README.md
+++ b/README.md
@@ -41,25 +41,39 @@ switch a chat into a repository you do not trust.
 - macOS 14 or newer with Messages signed in to iMessage
 - For RCS, an iPhone and carrier configuration that makes the RCS conversation
   available in Messages on the Mac
-- [Bun 1.3.14](https://bun.sh/) for source installation
-- [`imsg`](https://github.com/openclaw/imsg) 0.14 or a capability-compatible release
+- [Bun 1.3.14](https://bun.sh/) only for development from source
+- [`imsg`](https://github.com/openclaw/imsg) 0.15.0
 - At least one authenticated [Codex CLI](https://github.com/openai/codex) or
   [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code/getting-started)
 
 ## Quick start
 
-Install Bun and `imsg` if you do not already have them, then clone and run setup:
+Install `imsg`, download the signed binary for your Mac, verify its permanent
+Apple identity, and run setup:
 
 ```sh
-brew install oven-sh/bun/bun steipete/tap/imsg
-git clone https://github.com/eabnelson/pronto.git
-cd pronto
-bun install --frozen-lockfile
-bun run setup
+brew install steipete/tap/imsg
+PRONTO_INSTALL_DIR="$(mktemp -d)" || exit 1
+case "$(uname -m)" in
+  arm64) PRONTO_TARGET="darwin-arm64" ;;
+  x86_64) PRONTO_TARGET="darwin-x64" ;;
+  *) echo "Unsupported Mac architecture" >&2; exit 1 ;;
+esac
+PRONTO_CANDIDATE="$PRONTO_INSTALL_DIR/pronto"
+curl --fail --location --proto '=https' --tlsv1.2 \
+  "https://github.com/eabnelson/pronto/releases/latest/download/pronto-$PRONTO_TARGET" \
+  --output "$PRONTO_CANDIDATE" || exit 1
+chmod 700 "$PRONTO_CANDIDATE"
+codesign --verify --strict \
+  -R='identifier "dev.pronto.cli" and anchor apple generic and certificate leaf[subject.OU] = "9YCNUWK84C"' \
+  "$PRONTO_CANDIDATE" || exit 1
+"$PRONTO_CANDIDATE" setup
+unlink "$PRONTO_CANDIDATE"
+rmdir "$PRONTO_INSTALL_DIR"
 ```
 
-Codex or Claude Code must already be installed and signed in before `bun run
-setup`. Setup automatically detects both CLIs, lets you choose the primary and
+Codex or Claude Code must already be installed and signed in before setup.
+Setup automatically detects both CLIs, lets you choose the primary and
 optional fallback, and validates that every selected runtime can complete an
 unattended tool call before installing anything.
 
@@ -102,6 +116,12 @@ the compiled executable can launch on supported macOS versions. If you have a
 stable code-signing identity and want Full Disk Access to survive recompilation,
 set `PRONTO_CODESIGN_IDENTITY` to that identity before running setup. The value is
 passed directly to `/usr/bin/codesign`; it is never evaluated by a shell.
+
+Official release binaries use the permanent `dev.pronto.cli` Developer ID
+identity for Apple Team `9YCNUWK84C`, Hardened Runtime, a secure timestamp, and
+Apple notarization. Moving from a source-built/ad-hoc installation to the first
+official signed release requires one final Full Disk Access re-grant. Later
+official updates preserve the installed path and designated requirement.
 
 ## macOS permissions
 
@@ -165,6 +185,8 @@ PRONTO="$HOME/Library/Application Support/pronto/bin/pronto"
 "$PRONTO" tags
 "$PRONTO" tags add @plan
 "$PRONTO" tags remove @plan
+"$PRONTO" update --check
+"$PRONTO" update
 "$PRONTO" stop
 "$PRONTO" forget <opaque-chat-key>
 "$PRONTO" uninstall
@@ -190,7 +212,12 @@ local tool activity is also parked rather than replayed.
 
 ## Upgrade
 
-From the source checkout:
+Official installations update automatically every six hours. Check or update
+immediately with `pronto update --check` or `pronto update`. The updater verifies
+the signed manifest, artifact digest, and Apple identity, drains the listener,
+restarts it, and rolls back unless the new listener becomes healthy.
+
+Source installations remain a development workflow:
 
 ```sh
 git pull --ff-only
@@ -198,12 +225,13 @@ bun install --frozen-lockfile
 bun run packages/cli/src/cli.ts setup
 ```
 
-Setup replaces the stable executable atomically and preserves configuration and
-bounded memory. An ad-hoc-signed replacement has a new privacy identity; run
-`doctor` again after setup. If Pronto already appears in Full Disk Access, remove
-that entry and add the exact installed executable again; toggling the existing
-entry off and on does not refresh the replaced identity. A stable identity set
-through `PRONTO_CODESIGN_IDENTITY` preserves the identity across recompilation.
+Source setup replaces the stable executable atomically and preserves
+configuration and bounded memory, but its default ad-hoc signature has a new
+privacy identity on every build. Use source setup only for development. Move to
+the first official release by downloading and verifying the signed candidate as
+shown in Quick start, then run `"$PRONTO_CANDIDATE" update --migrate-signing`.
+Re-grant Full Disk Access once and use automatic signed updates thereafter. See
+[Signed releases and automatic updates](docs/UPDATES.md).
 
 ## Troubleshooting
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,6 +52,21 @@ Possible-side-effect runtime failures and uncertain sends are never replayed
 automatically. Trigger tags and prompt labels reduce accidental activation and
 prompt injection risk, but are not authorization or process isolation.
 
+## Release and update trust
+
+Official macOS binaries are signed with the stable `dev.pronto.cli` Developer ID
+identity for Team `9YCNUWK84C`, use Hardened Runtime and a secure timestamp, and
+must be accepted by Apple's notarization service before publication. The updater
+also requires a bounded Ed25519-signed manifest, an immutable GitHub release URL,
+the exact artifact size and SHA-256, a monotonically increasing release sequence,
+and the expected Apple identity. A failed check leaves the installed binary
+unchanged; a candidate that does not become healthy is rolled back.
+
+Release credentials are GitHub environment secrets and are never stored in this
+repository. Pull-request workflows cannot access the protected `release`
+environment. npm publication uses trusted publishing/OIDC rather than a durable
+npm token. See [the update runbook](docs/UPDATES.md) for the complete contract.
+
 ## Reporting vulnerabilities
 
 Do not include real message text, participant identifiers, chat identifiers,

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
     },
     "packages/cli": {
       "name": "pronto-cli",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "bin": {
         "pronto": "./src/cli.ts",
         "s4imsg": "./src/legacy-cli.ts",
@@ -24,7 +24,7 @@
     },
     "packages/messages": {
       "name": "pronto-imessage",
-      "version": "0.2.4",
+      "version": "0.3.0",
     },
   },
   "packages": {

--- a/docs/RELEASE_QUALIFICATION.md
+++ b/docs/RELEASE_QUALIFICATION.md
@@ -15,9 +15,9 @@ file records capability evidence, not private conversation data.
 | Claude Code | 2.1.260 | Auth/help inspection and adapter fixtures | Pass |
 | Codex effective local probe | 0.153.0 | Setup noninteractive file-tool probe | Pass |
 | Claude effective local probe | 2.1.226 | Setup noninteractive file-tool probe | Pass |
-| Messages Automation | v0.3.0 signed candidate | Pending Developer ID build, one-time FDA migration, and exactly-one send evidence | Pending |
-| Self-chat mirror handling | v0.3.0 signed candidate | Pending one tagged activation and one agent send with no echo turn | Pending |
-| Full remote tagged flow | v0.3.0 | Pending exact signed candidate remote-chat evidence and signed-to-signed update continuity | Pending |
+| Messages Automation | v0.3.0 signed candidate | Developer ID candidate installed after the one-time FDA migration; owner-authorized self and remote sends each produced exactly one reply on 2026-09-04 | Pass |
+| Self-chat mirror handling | v0.3.0 signed candidate | One tagged self-chat activation produced exactly one agent send with no echo turn after one minute on 2026-09-04 | Pass |
+| Full remote tagged flow | v0.3.0 signed candidate | One remote participant's tagged request produced exactly one reply; a same-identity signed-to-signed replacement preserved FDA and returned the listener to ready on 2026-09-04 | Pass |
 
 The automated matrix and owner smoke record versions tested on 2026-09-04.
 Capability checks, not version

--- a/docs/RELEASE_QUALIFICATION.md
+++ b/docs/RELEASE_QUALIFICATION.md
@@ -10,16 +10,16 @@ file records capability evidence, not private conversation data.
 | macOS | 26.5.1 (25F80) | Local build and synthetic suite | Pass |
 | Bun | 1.3.14 | Frozen install, typecheck, tests, compiled build | Pass |
 | Node.js | 22.23.1 | Clean packed `pronto-imessage` import and public-interface smoke | Pass |
-| imsg | 0.14.1 | Protocol v1 initialize, database readiness, method qualification | Pass |
+| imsg | 0.15.0 | Exact signed upstream artifact qualified against protocol v1; provider code unchanged since the 0.2.4 qualification | Pass |
 | Codex CLI | 0.153.0 | Auth/help inspection and adapter fixtures | Pass |
-| Claude Code | 2.1.226 | Auth/help inspection and adapter fixtures | Pass |
+| Claude Code | 2.1.260 | Auth/help inspection and adapter fixtures | Pass |
 | Codex effective local probe | 0.153.0 | Setup noninteractive file-tool probe | Pass |
 | Claude effective local probe | 2.1.226 | Setup noninteractive file-tool probe | Pass |
-| Messages Automation | Owner test chats, 2026-09-03 | Exact v0.2.3 candidate produced one self-chat reply; v0.2.2 RCS send evidence carried forward | Pass |
-| Self-chat mirror handling | Owner self-chat, 2026-09-03 | Exact v0.2.3 candidate produced one tagged activation and one agent send with no echo turn | Pass |
-| Full remote tagged flow | v0.2.3 | Release-owner exception: exact v0.2.3 self-chat passed on 2026-09-03; v0.2.2 owner RCS evidence from 2026-09-02 carried forward after diff review confirmed no activation, transport, runtime, delivery, or echo-suppression changes | Pass |
+| Messages Automation | v0.3.0 signed candidate | Pending Developer ID build, one-time FDA migration, and exactly-one send evidence | Pending |
+| Self-chat mirror handling | v0.3.0 signed candidate | Pending one tagged activation and one agent send with no echo turn | Pending |
+| Full remote tagged flow | v0.3.0 | Pending exact signed candidate remote-chat evidence and signed-to-signed update continuity | Pending |
 
-The automated matrix and owner smoke record versions tested on 2026-09-03.
+The automated matrix and owner smoke record versions tested on 2026-09-04.
 Capability checks, not version
 strings alone, determine whether setup and startup proceed.
 

--- a/docs/UPDATES.md
+++ b/docs/UPDATES.md
@@ -1,0 +1,94 @@
+# Signed releases and automatic updates
+
+Pronto has two independent release surfaces:
+
+- The standalone `pronto` executable owns its installed path, LaunchAgents,
+  macOS privacy identity, signed update manifest, qualification, and rollback.
+- The public `pronto-imessage` package is an in-process library. Consumers such
+  as Studio Four exact-pin it and ship it inside their own signed host. Pronto
+  never mutates a consumer's embedded copy.
+
+## User lifecycle
+
+Setup installs the listener at
+`~/Library/Application Support/pronto/bin/pronto` and a periodic
+`dev.pronto.updater` LaunchAgent. The updater runs every six hours, stays quiet
+when the installed version is current or the network is unavailable, and only
+installs a newer stable release after every authenticity check passes.
+
+Existing source-built releases are ad-hoc signed. Automatic update refuses to
+replace one because doing so would invalidate its Full Disk Access identity.
+The old binary cannot update itself because the update command begins in 0.3.0.
+Download and verify the official signed candidate using the Quick start steps,
+then run the migration from that separate candidate path:
+
+```sh
+"$PRONTO_CANDIDATE" update --migrate-signing
+```
+
+After the signed binary is installed, remove the stale Pronto row from System
+Settings → Privacy & Security → Full Disk Access, add the exact installed path,
+and run `pronto doctor` and `pronto status`. Future signed-to-signed updates keep
+the same path, identifier, and Team ID and do not rerun setup.
+
+Manual controls remain available:
+
+```sh
+pronto update --check
+pronto update
+```
+
+## Verification and promotion
+
+The latest pointer is
+`https://github.com/eabnelson/pronto/releases/latest/download/pronto-update.json`.
+It is safe to be mutable because its envelope is signed by a release key whose
+public half is embedded in Pronto. The signed payload binds:
+
+- schema, product, stable channel, semantic version, and release sequence;
+- publication and expiry times, source revision, and minimum updater version;
+- one immutable GitHub release URL per macOS architecture;
+- exact byte size, SHA-256, signing identifier, and Apple Team ID.
+
+The updater verifies the envelope before parsing its payload, rejects replay and
+downgrade, downloads with time and size bounds into an owner-private directory,
+verifies the artifact and Apple designated requirement, and executes the
+candidate's version command. It then gracefully unloads the listener, atomically
+replaces the executable, refreshes the stored integrity hash, restarts launchd,
+and waits for content-free health. Failure restores the last-known-good binary
+and configuration. The old updater process remains alive during this transaction,
+so it can roll back even when the candidate cannot start.
+
+## Release credentials
+
+The public repository contains only the public manifest key, Team ID, signing
+identifier, workflow logic, and secret names. Configure these in the protected
+GitHub `release` environment:
+
+- `PRONTO_DEVELOPER_ID_P12_B64`
+- `PRONTO_DEVELOPER_ID_P12_PASSWORD`
+- `PRONTO_NOTARY_KEY_P8_B64`
+- `PRONTO_NOTARY_KEY_ID`
+- `PRONTO_NOTARY_ISSUER_ID`
+- `PRONTO_RELEASE_ED25519_PRIVATE_KEY`
+
+The environment permits only `v*` tags and requires release-owner approval. The
+workflow checks out that immutable tag, runs all tests and live-evidence gates,
+imports the certificate into a temporary keychain on a GitHub-hosted macOS
+runner, signs with Hardened Runtime and timestamping, verifies the exact
+designated requirement, submits both architectures to `notarytool`, and deletes
+all temporary signing material in an `always()` step.
+
+The publish job receives no Apple or manifest private key. It verifies checksums,
+creates GitHub artifact attestations, publishes `pronto-imessage` through npm
+OIDC with provenance, verifies registry propagation, and only then makes the
+immutable GitHub release public.
+
+## Release qualification
+
+Before tagging a release, install the exact signed candidate over the prior
+signed production release on every supported macOS version. Confirm that Full
+Disk Access remains effective from the launchd-started listener, one explicit
+tag produces exactly one reply, an active turn drains before replacement, and a
+synthetically broken candidate rolls back. Record only content-free evidence in
+`docs/RELEASE_QUALIFICATION.md`.

--- a/docs/research/2026-09-04-secure-pronto-updates.md
+++ b/docs/research/2026-09-04-secure-pronto-updates.md
@@ -1,0 +1,124 @@
+# Secure signing, notarization, and updates for Pronto
+
+- **Research date:** 2026-09-04
+- **Pronto inspected:** `c489bcf` (`0.2.4` work in progress; released baseline `0.2.3`)
+- **Studio Four inspected:** `238646e` (exactly pins `pronto-imessage@0.2.3`)
+- **Source policy:** Apple, GitHub, and npm primary documentation plus local Pronto and Studio Four source
+
+## Decision
+
+Pronto should have two independent trust layers:
+
+1. Sign every official macOS executable with one stable **Developer ID Application** identity, the permanent identifier `dev.pronto.cli`, Hardened Runtime, and a secure timestamp; then notarize the exact distributed bytes.
+2. Authenticate update metadata with a dedicated, rotatable Ed25519 release key embedded in Pronto. A signed manifest must bind a monotonic release sequence to the artifact URL, byte length, SHA-256, source revision, required updater version, and expected macOS Team ID plus signing identifier.
+
+Developer ID establishes Apple-recognized code identity and is what lets macOS recognize an updated executable as the same program. It does not prevent a compromised download host from serving an older valid release. The signed update manifest provides origin, freshness, and rollback resistance; HTTPS and unsigned checksum sidecars do not.
+
+Do not make Studio Four dynamically install or update the standalone Pronto binary. `pronto-imessage` is an in-process library whose consumers explicitly own installation, updates, signing, LaunchAgent identity, and permissions ([ADR 0003](../adr/0003-scope-messages-access-to-observed-conversations.md#consequences)). Studio Four should continue to exact-pin the npm package, compile it into its own Developer ID-signed host, and ship that host through Studio Four's existing signed-maintenance path.
+
+## Priority
+
+| Priority | Recommendation |
+| --- | --- |
+| **Must, before an official unattended update** | Replace Pronto's ad-hoc release signature with stable Developer ID signing, Hardened Runtime, timestamping, notarization, and exact identifier/Team verification. |
+| **Must** | Put Apple credentials in a protected GitHub `release` environment; expose them only to a manually approved release job from an immutable tag. Never expose them to PR, `pull_request_target`, third-party code, or a persistent self-hosted runner. |
+| **Must** | Publish and verify a signed, bounded update manifest. Persist the highest installed release sequence and reject replay/downgrade. Keep one last-known-good binary and replace atomically only after full verification. |
+| **Must** | Treat the Developer ID PKCS#12, notarization API `.p8`, and update-manifest signing key as three different credentials with separate rotation and revocation procedures. |
+| **Should** | Ship a signed and stapled flat `.pkg` (or signed/stapled `.dmg`) as the human-facing installer. Keep a notarized ZIP/binary for the updater, while accepting that Apple cannot staple a ticket directly to a ZIP or standalone binary. |
+| **Should** | Add GitHub artifact attestations for the Pronto binary and continue npm trusted publishing/provenance for `pronto-imessage`; these add auditable build provenance but do not replace runtime manifest verification. |
+| **Defer** | Background auto-update until manual `pronto update` has field evidence for permission continuity, drain/restart, health qualification, and rollback on each supported macOS version. |
+
+## Stable signing and Full Disk Access
+
+Apple documents a designated requirement (DR) as the rule macOS uses to decide whether new code is the same code it saw before. It specifically describes privacy authorization surviving an update when the new version satisfies the original DR; unsigned code has no DR, while an ad-hoc DR is tied to one build ([TN3127](https://developer.apple.com/documentation/technotes/tn3127-inside-code-signing-requirements), [Applying Code Requirements](https://developer.apple.com/documentation/security/applying-code-requirements)). A default Developer ID DR includes an Apple-issued anchor, the developer Team ID, and the signing identifier. Consequently:
+
+- Keep `dev.pronto.cli` and the chosen Apple Developer Team ID immutable across releases and certificate renewal.
+- Inspect every release with `codesign --display --requirements - --verbose=4`, and verify it against `anchor apple generic and identifier "dev.pronto.cli" and certificate leaf[subject.OU] = "<TEAM_ID>"`.
+- Sign the actual responsible executable installed at `~/Library/Application Support/pronto/bin/pronto`; keep that stable path and LaunchAgent relationship.
+- Expect one permission re-grant when moving existing ad-hoc installations to the first Developer ID-signed build. Thereafter, a binary that satisfies the same original DR should retain privacy authorization.
+- Changing signer team, identifier, distribution mode, or responsible process is an identity migration and may require a new grant.
+
+This is strong evidence for TCC continuity, but Apple does not explicitly guarantee every manual Full Disk Access transition for every launcher/path combination. Treat FDA persistence as a release qualification test, not a theorem: install the prior production build, grant FDA, upgrade using the candidate path, restart the LaunchAgent, and prove a bounded `chat.db` read without touching the System Settings grant. Test the actual launcher attribution chain on each supported macOS release. Apple's managed-device PPPC documentation likewise binds System Policy All Files access to a code-signing requirement ([PPPC payload](https://support.apple.com/guide/deployment/privacy-preferences-policy-control-payload-dep38df53c2a/web)).
+
+Pronto already preserves the installation path and atomically renames a staged executable into place (`packages/cli/src/macos/setup.ts:652-700`), but official CI currently produces only an ad-hoc signature: `signProntoExecutable` defaults to `-` and supplies neither Hardened Runtime nor timestamp (`packages/cli/src/macos/setup.ts:577-605`; `scripts/build.ts:18-35`). The release workflow verifies that this ad-hoc signature is internally valid but does not check Team ID, notarize, or assess Gatekeeper (`.github/workflows/release.yml:43-50`). That is insufficient for stable TCC identity or external distribution.
+
+Apple's current notarization requirements are a Developer ID certificate, valid signatures on all executables, Hardened Runtime for command-line targets, a secure timestamp, no true `get-task-allow`, and an appropriate SDK ([Notarizing macOS software](https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution), [Creating distribution-signed code](https://developer.apple.com/documentation/xcode/creating-distribution-signed-code-for-the-mac)). For Pronto's single Mach-O, sign with `codesign --force --options runtime --timestamp --identifier dev.pronto.cli --sign <identity>`. Use `--deep` only for verification, not signing nested code.
+
+## Credentials in a public GitHub repository
+
+GitHub encrypts Actions secrets before upload, injects them only when a workflow explicitly references them, and can delay environment secrets until required approval ([Secrets](https://docs.github.com/en/actions/concepts/security/secrets), [Deployments and environments](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments)). Masking is not a security boundary: code executing in a privileged job can read and exfiltrate its environment ([Compromised runners](https://docs.github.com/en/actions/concepts/security/compromised-runners)). The safe boundary is therefore the workflow and revision allowed to receive the secret.
+
+Use a `release` environment with required reviewers and tag-only deployment rules. The signing/notarization job should run on an ephemeral GitHub-hosted macOS runner, checkout the already reviewed immutable tag by full commit SHA, use least-privilege `GITHUB_TOKEN` permissions, pin every action to a full commit SHA, and never run on PR events. Avoid `pull_request_target` and persistent self-hosted runners for this public repository; GitHub explicitly warns that untrusted workflow code can compromise them ([Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)).
+
+Store these separately:
+
+- `PRONTO_DEVELOPER_ID_P12_B64` and its strong import password: code-signing certificate plus private key.
+- `PRONTO_NOTARY_KEY_P8_B64`, key ID, and issuer ID: notarization authentication only.
+- `PRONTO_RELEASE_ED25519_PRIVATE_KEY`: signs exact manifest payload bytes, never binaries.
+
+Base64 is transport encoding, not protection. Materialize credentials under `$RUNNER_TEMP`, import the PKCS#12 into a fresh randomly-passworded temporary keychain, restrict the keychain search list, and delete both keychain and files in an `always()` cleanup step. Do not print identities beyond the public certificate subject/Team ID, enable shell tracing, pass secrets as command arguments when avoidable, cache the keychain, upload it as an artifact, or let release-time scripts execute arbitrary unreviewed inputs. Rotate immediately on suspected exposure.
+
+Studio Four's current release workflow is a useful implementation template: it creates a temporary keychain, imports the PKCS#12, signs with `--options runtime --timestamp`, checks exact identifier and Team ID, notarizes, and removes temporary material (`/Users/erik/Studio/studiofour/studiofour/.github/workflows/cli-release.yml:70-144,194-210`). For a public Pronto repo, add the protected environment/manual gate and use GitHub-hosted rather than Studio Four's persistent self-hosted runner.
+
+### Notarization authentication
+
+Use a **team** App Store Connect API key with `notarytool`, not an individual key and not `altool`. Apple states that individual API keys cannot use `notarytool`; team keys are role-scoped but cover all apps and are downloadable only once ([Creating API Keys](https://developer.apple.com/documentation/appstoreconnectapi/creating-api-keys-for-app-store-connect-api)). Submit with `xcrun notarytool submit <archive> --issuer <issuer> --key-id <id> --key <p8-path> --wait`, require `Accepted`, and inspect the notarization log even on success ([TN3147](https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool), [Customizing notarization](https://developer.apple.com/documentation/security/customizing-the-notarization-workflow)).
+
+The API key is appropriate because it is revocable and removes a human Apple ID/app-specific password from CI. It cannot sign code and must not be confused with the Developer ID key. Choose the least role that successfully notarizes for the team and test it; Apple lists notarization as a role-controlled developer-program permission ([roles](https://developer.apple.com/help/account/access/roles)).
+
+A ZIP is accepted for notarization, but Apple cannot staple a ticket to a ZIP or standalone binary. Gatekeeper can retrieve its online ticket. A signed flat installer package or disk image can carry a stapled ticket and is preferable for offline first launch ([Customizing notarization](https://developer.apple.com/documentation/security/customizing-the-notarization-workflow)).
+
+## Update manifest and installer contract
+
+The current Pronto release publishes SHA-256 sidecars and rechecks them between CI jobs (`.github/workflows/release.yml:69-86,128-141`). That detects corruption inside the workflow, but a checksum beside a binary on the same mutable hosting authority is not an authenticity or anti-rollback mechanism.
+
+Publish an immutable, versioned manifest envelope no larger than 64 KiB:
+
+```json
+{
+  "keyId": "pronto-release-v1",
+  "payload": "<base64url exact JSON bytes>",
+  "signature": "<Ed25519 signature over payload bytes>"
+}
+```
+
+The payload should contain `schemaVersion`, `product`, semantic `version`, strictly increasing `releaseSequence`, `channel`, `publishedAt`, `expiresAt`, `sourceRevision`, `minimumUpdaterVersion`, and one artifact per architecture with an allowlisted HTTPS URL, exact byte `size`, `sha256`, `macosSigning.identifier`, and `macosSigning.teamIdentifier`. Include release-key rotation metadata and a security/capability-expansion marker. Sign bytes rather than reparsed JSON.
+
+Embed trusted public keys and their status in Pronto. Verify envelope size, key ID/status, Ed25519 signature, schema, time bounds, stable channel, updater compatibility, sequence monotonicity, exact URL origin/path, and target before downloading. Download into a private directory with a size cap and timeout; verify length and SHA-256; verify strict codesign validity plus the exact DR; then run a bounded version/self-test. Stop and drain the daemon, stage with mode `0700`, atomically rename, update the configured installed hash, restart, and qualify database/watch health before promotion. Preserve the old binary and prior state until qualification; rollback on startup failure. Never interpret rollback as permission to replay an ambiguous outbound message.
+
+Persist the highest accepted `releaseSequence` separately from the replaceable binary so a valid old manifest cannot downgrade it. Allow an explicit, authenticated emergency rollback sequence to point to older artifact bytes; do not lower the sequence. Key rotation should ship the next public key in an earlier trusted release with an overlap window and explicit revocation state.
+
+Studio Four already implements most of this pattern: Ed25519 envelopes, bounded fetches, expiry and release-sequence checks, capability coverage, digest and stable code-identity verification, idle-boundary install, candidate qualification, last-known-good rollback, and bounded retention (`/Users/erik/Studio/studiofour/studiofour/packages/channel-host/src/maintenance.ts:17-161,237-388`; `packages/channel-host/src/macos/launcher.ts:123-235,319-330`). Reuse the design and tests, not a shared runtime updater abstraction.
+
+GitHub artifact attestations can additionally bind a binary to repository, workflow, commit, and triggering event; use `id-token: write`, `attestations: write`, and a SHA-pinned `actions/attest` on the built assets ([GitHub artifact attestations](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations)). They are valuable audit evidence, but Pronto's updater should remain self-contained around its embedded manifest public key.
+
+## Phased delivery
+
+### Phase 0 — release identity (blocker)
+
+Choose and record Pronto's Team ID; keep `dev.pronto.cli`; move release signing to a protected GitHub-hosted macOS job; add Hardened Runtime, timestamp, strict DR/Team checks, notarization, log inspection, and a clean-Mac Gatekeeper smoke. Publish signed/stapled `.pkg` plus the updater's notarized archive. Qualify the one-time ad-hoc-to-Developer-ID permission migration and a subsequent signed-to-signed upgrade.
+
+### Phase 1 — verified manual update
+
+Add `pronto update --check` and explicit `pronto update` only. Introduce the signed manifest, immutable version paths, monotonic sequence state, bounded download, exact DR/digest validation, atomic replacement, last-known-good rollback, and privacy-safe diagnostics. A failed or offline check must leave the installed executable unchanged.
+
+### Phase 2 — supervised automatic update
+
+Only after field evidence, check at a drained turn boundary; never interrupt an accepted send. Stage and restart under the stable launcher, require heartbeat plus database/watch qualification, promote only after success, and roll back otherwise. Defer on active work, treat signature/replay/identity failures as action-required, apply bounded rollout, and retain current plus one known-good release.
+
+### Phase 3 — Studio Four consumption
+
+Keep `packages/channel-host/package.json` on an exact `pronto-imessage` version and commit its `bun.lock` SHA-512 resolution (`/Users/erik/Studio/studiofour/studiofour/packages/channel-host/package.json:27`; `/Users/erik/Studio/studiofour/studiofour/bun.lock:1570`). For each bump, verify npm provenance/signatures, run provider conformance and the live iMessage matrix, then release a newly signed/notarized Studio Four host through Studio Four's own manifest. Do not let standalone Pronto update Studio Four's embedded copy or share its identifier/path.
+
+Pronto already publishes `pronto-imessage` through npm OIDC with no npm token and requests provenance (`.github/workflows/release.yml:88-99,118-127,156-164`). Keep that. npm trusted publishing requires Node 22.14+ and npm 11.5.1+, eliminates the long-lived npm token, and automatically creates provenance for public packages from public repositories ([Trusted publishing](https://docs.npmjs.com/trusted-publishers/), [provenance](https://docs.npmjs.com/generating-provenance-statements/)). Consumers can audit registry signatures and attestations with `npm audit signatures`. Provenance proves where the package was built; Studio Four's exact pin, lock integrity, review, and conformance tests still decide whether that build is acceptable.
+
+## Release acceptance evidence
+
+Before enabling automatic updates, require all of the following from the exact published artifact:
+
+- Developer ID Application authority, expected Team ID and `dev.pronto.cli`, Hardened Runtime flag, secure timestamp, strict signature verification, accepted notarization, clean log, and Gatekeeper assessment.
+- Previous signed production build retains FDA and Messages Automation through the update on each supported macOS release; the first ad-hoc-to-signed migration is documented separately.
+- Tampered manifest, unknown/revoked key, expired manifest, wrong origin/path/target, altered size/hash, wrong Team/identifier, replayed sequence, and downgrade all fail closed without touching the installed binary.
+- Power loss/interruption before and during rename recovers to current or last-known-good; candidate startup or qualification failure rolls back.
+- An active turn defers update; an accepted send drains before restart; rollback never resends an uncertain effect.
+- The published `pronto-imessage` tarball has npm provenance/signatures, matches the exact reviewed version and lock integrity, and passes Studio Four conformance/live qualification before Studio Four release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-workspace",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "A local iMessage bridge for Codex and Claude Code",
   "type": "module",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-cli",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -47,6 +47,7 @@ import {
   PRONTO_ATTEMPT_CAPABILITY_ENV,
   PRONTO_BROKER_URL_ENV,
 } from "./tools/contract";
+import { ProntoUpdater } from "./update";
 
 const HELP = `pronto ${packageJson.version}
 
@@ -58,6 +59,7 @@ Commands:
   status      Show listener health without conversation content
   doctor      Check local capabilities and permissions
   tags        List, add, or remove trigger tags
+  update      Check for or install a verified Pronto update
   stop        Stop the installed listener
   forget      Remove one chat's tagged memory and workspace state
   uninstall   Remove the listener while preserving data by default
@@ -250,6 +252,65 @@ async function runSetup(): Promise<number> {
     return 0;
   } finally {
     prompt.close();
+  }
+}
+
+async function runUpdate(args: readonly string[]): Promise<number> {
+  if (process.platform !== "darwin") {
+    console.error("Pronto updates require macOS.");
+    return 1;
+  }
+  const automatic = args.includes("--automatic");
+  const checkOnly = args.includes("--check");
+  const allowIdentityMigration = args.includes("--migrate-signing");
+  const updater = new ProntoUpdater(pathsForHome(homedir()));
+  try {
+    if (
+      allowIdentityMigration &&
+      resolve(process.execPath) !== resolve(pathsForHome(homedir()).executablePath)
+    ) {
+      const result = await updater.migrateLocalCandidate(process.execPath);
+      if (result.status === "migration_installed") {
+        console.log(fullDiskAccessInstructions(pathsForHome(homedir()).executablePath));
+        console.log("After granting access, run pronto doctor and pronto status. Future updates will preserve this identity.");
+        return 2;
+      }
+      console.log(result.status === "installed"
+        ? `Pronto migrated to signed ${result.version}.`
+        : `Pronto ${result.version} already has the permanent release identity.`);
+      return 0;
+    }
+    if (checkOnly) {
+      const result = await updater.check();
+      console.log(result.status === "current"
+        ? `Pronto ${result.version} is current.`
+        : `Pronto ${result.manifest.version} is available.`);
+      return 0;
+    }
+    const result = await updater.install({ allowIdentityMigration });
+    if (result.status === "current") {
+      if (!automatic) console.log(`Pronto ${result.version} is current.`);
+      return 0;
+    }
+    if (result.status === "migration_required") {
+      if (!automatic) {
+        console.error(
+          `Pronto ${result.version} is signed with the permanent release identity. ` +
+          "Run pronto update --migrate-signing to install it; macOS will require one final Full Disk Access re-grant.",
+        );
+      }
+      return automatic ? 0 : 2;
+    }
+    if (result.status === "migration_installed") {
+      console.log(fullDiskAccessInstructions(pathsForHome(homedir()).executablePath));
+      console.log("After granting access, run pronto doctor and pronto status. Future updates will preserve this identity.");
+      return 2;
+    }
+    console.log(`Pronto updated to ${result.version}.`);
+    return 0;
+  } catch (error) {
+    console.error(`Pronto update failed: ${(error as Error).message}`);
+    return automatic ? 0 : 1;
   }
 }
 
@@ -488,6 +549,7 @@ export async function runCli(args: readonly string[]): Promise<number> {
   if (command === "doctor") return runDoctor(args.includes("--json"), args.includes("--offline"));
   if (command === "status") return runStatus(args.includes("--json"), args.includes("--chats"));
   if (command === "tags" || command === "tag") return runTags(args.slice(1));
+  if (command === "update") return runUpdate(args.slice(1));
   if (command === "stop") {
     const result = await stopLaunchAgent();
     if (result.exitCode !== 0) console.error("Pronto was not running.");

--- a/packages/cli/src/macos/launch-agent.ts
+++ b/packages/cli/src/macos/launch-agent.ts
@@ -1,7 +1,7 @@
 import { unlink } from "node:fs/promises";
 import { dirname } from "node:path";
 import { atomicWritePrivate } from "../config";
-import { LAUNCH_AGENT_LABEL } from "./paths";
+import { LAUNCH_AGENT_LABEL, UPDATER_LAUNCH_AGENT_LABEL } from "./paths";
 
 export interface ProcessResult {
   exitCode: number;
@@ -87,6 +87,35 @@ export function renderLaunchAgent(input: {
 `;
 }
 
+export function renderUpdaterLaunchAgent(input: {
+  executablePath: string;
+  logPath: string;
+}): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${UPDATER_LAUNCH_AGENT_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${xml(input.executablePath)}</string>
+    <string>update</string>
+    <string>--automatic</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>21600</integer>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>StandardOutPath</key>
+  <string>${xml(input.logPath)}</string>
+  <key>StandardErrorPath</key>
+  <string>${xml(input.logPath)}</string>
+</dict>
+</plist>
+`;
+}
+
 export const runLaunchctl: LaunchctlRunner = async (args) => {
   const child = Bun.spawn(["/bin/launchctl", ...args], {
     stderr: "pipe",
@@ -107,24 +136,52 @@ export async function installLaunchAgent(input: {
   uid?: number;
   wait?: (milliseconds: number) => Promise<void>;
 }): Promise<void> {
+  await installLaunchAgentForLabel({ ...input, label: LAUNCH_AGENT_LABEL, kickstart: true });
+}
+
+export async function installUpdaterLaunchAgent(input: {
+  plist: string;
+  plistPath: string;
+  runner?: LaunchctlRunner;
+  uid?: number;
+  wait?: (milliseconds: number) => Promise<void>;
+}): Promise<void> {
+  await installLaunchAgentForLabel({
+    ...input,
+    label: UPDATER_LAUNCH_AGENT_LABEL,
+    kickstart: false,
+  });
+}
+
+async function installLaunchAgentForLabel(input: {
+  plist: string;
+  plistPath: string;
+  label: string;
+  kickstart: boolean;
+  runner?: LaunchctlRunner;
+  uid?: number;
+  wait?: (milliseconds: number) => Promise<void>;
+}): Promise<void> {
   const runner = input.runner ?? runLaunchctl;
   const wait = input.wait ?? Bun.sleep;
   const uid = input.uid ?? process.getuid?.();
   if (uid === undefined) throw new Error("Unable to determine the current user ID");
-  const service = `gui/${uid}/${LAUNCH_AGENT_LABEL}`;
+  const service = `gui/${uid}/${input.label}`;
 
   await atomicWritePrivate(input.plistPath, input.plist);
-  await stopLaunchAgentForLabel({ label: LAUNCH_AGENT_LABEL, runner, uid, wait });
+  await stopLaunchAgentForLabel({ label: input.label, runner, uid, wait });
   const bootstrap = await runner(["bootstrap", `gui/${uid}`, input.plistPath]);
   if (bootstrap.exitCode !== 0) {
     await unlink(input.plistPath).catch(() => undefined);
     throw new Error(`launchctl bootstrap failed: ${bootstrap.stderr.trim() || bootstrap.exitCode}`);
   }
-  const kickstart = await runner(["kickstart", "-k", service]);
-  if (kickstart.exitCode !== 0) {
-    await runner(["bootout", service]);
-    await unlink(input.plistPath).catch(() => undefined);
-    throw new Error(`launchctl kickstart failed: ${kickstart.stderr.trim() || kickstart.exitCode}`);
+  if (input.kickstart) {
+    const kickstart = await runner(["kickstart", "-k", service]);
+    if (kickstart.exitCode !== 0) {
+      await runner(["bootout", service]);
+      await unlink(input.plistPath).catch(() => undefined);
+      throw new Error(`launchctl kickstart failed: ${kickstart.stderr.trim() || kickstart.exitCode}`);
+    }
   }
 }
 

--- a/packages/cli/src/macos/paths.ts
+++ b/packages/cli/src/macos/paths.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 
 export const LAUNCH_AGENT_LABEL = "dev.pronto.agent";
+export const UPDATER_LAUNCH_AGENT_LABEL = "dev.pronto.updater";
 export const LEGACY_LAUNCH_AGENT_LABEL = "dev.s4imsg.agent";
 
 export interface ProntoPaths {
@@ -12,6 +13,11 @@ export interface ProntoPaths {
   logDirectory: string;
   logPath: string;
   providerStatePath: string;
+  updateBackupPath: string;
+  updateDirectory: string;
+  updateLockPath: string;
+  updateStatePath: string;
+  updaterLaunchAgentPath: string;
 }
 
 function productPathsForHome(input: {
@@ -27,6 +33,7 @@ function productPathsForHome(input: {
     input.product,
   );
   const logDirectory = join(input.homeDirectory, "Library", "Logs", input.product);
+  const updateDirectory = join(appSupportDirectory, "updates");
   return {
     appSupportDirectory,
     configPath: join(appSupportDirectory, "config.json"),
@@ -41,6 +48,18 @@ function productPathsForHome(input: {
     logDirectory,
     logPath: join(logDirectory, "daemon.log"),
     providerStatePath: join(appSupportDirectory, "provider-state.json"),
+    updateBackupPath: join(updateDirectory, "last-known-good"),
+    updateDirectory,
+    updateLockPath: join(updateDirectory, "update.lock"),
+    updateStatePath: join(updateDirectory, "state.json"),
+    updaterLaunchAgentPath: join(
+      input.homeDirectory,
+      "Library",
+      "LaunchAgents",
+      input.label === LAUNCH_AGENT_LABEL
+        ? `${UPDATER_LAUNCH_AGENT_LABEL}.plist`
+        : `${input.label}.updater.plist`,
+    ),
   };
 }
 

--- a/packages/cli/src/macos/release-identity.ts
+++ b/packages/cli/src/macos/release-identity.ts
@@ -1,0 +1,22 @@
+export const PRONTO_SIGNING_IDENTIFIER = "dev.pronto.cli";
+export const PRONTO_SIGNING_TEAM_IDENTIFIER = "9YCNUWK84C";
+
+export type ReleaseIdentityRunner = (
+  executable: string,
+  args: readonly string[],
+) => Promise<{ readonly exitCode: number; readonly stderr: string; readonly stdout: string }>;
+
+export async function inspectProntoExecutableIdentity(
+  path: string,
+  run: ReleaseIdentityRunner,
+): Promise<{ readonly identifier: string; readonly teamIdentifier: string } | undefined> {
+  const requirement = `identifier "${PRONTO_SIGNING_IDENTIFIER}" and anchor apple generic and certificate leaf[subject.OU] = "${PRONTO_SIGNING_TEAM_IDENTIFIER}"`;
+  const verified = await run("/usr/bin/codesign", ["--verify", "--strict", `-R=${requirement}`, path]);
+  if (verified.exitCode !== 0) return undefined;
+  const detail = await run("/usr/bin/codesign", ["-d", "--verbose=4", path]);
+  if (detail.exitCode !== 0) return undefined;
+  const identifier = /^Identifier=(.+)$/mu.exec(detail.stderr)?.[1]?.trim();
+  const teamIdentifier = /^TeamIdentifier=(.+)$/mu.exec(detail.stderr)?.[1]?.trim();
+  if (identifier === undefined || teamIdentifier === undefined) return undefined;
+  return { identifier, teamIdentifier };
+}

--- a/packages/cli/src/macos/setup.ts
+++ b/packages/cli/src/macos/setup.ts
@@ -15,17 +15,25 @@ import {
 } from "../config";
 import {
   installLaunchAgent,
+  installUpdaterLaunchAgent,
   launchAgentStateForLabel,
   removeLaunchAgent,
   removeLaunchAgentForLabel,
   renderLaunchAgent,
+  renderUpdaterLaunchAgent,
   restoreLaunchAgentForLabel,
   stopLaunchAgentForLabel,
   type LaunchAgentState,
   type ProcessResult,
 } from "./launch-agent";
-import { LAUNCH_AGENT_LABEL, LEGACY_LAUNCH_AGENT_LABEL, type ProntoPaths } from "./paths";
+import {
+  LAUNCH_AGENT_LABEL,
+  LEGACY_LAUNCH_AGENT_LABEL,
+  UPDATER_LAUNCH_AGENT_LABEL,
+  type ProntoPaths,
+} from "./paths";
 import { renderCompatibilityLauncher } from "../compatibility";
+import { inspectProntoExecutableIdentity } from "./release-identity";
 
 export const TRUST_DISCLOSURE = `The trigger tag is not authentication: any participant, current or future, in an eligible iMessage or RCS conversation can instruct your selected local agent. Claude Code and Codex will bypass their approval and sandbox prompts and can run commands or change files anywhere this macOS user can access. Adding a participant or eligible chat does not ask for consent again; untagged messages and attachments are untrusted evidence but may still influence the model. A selected folder's project instructions, hooks, and MCP servers may also run with this unrestricted access. Conversation material may be sent to your selected model provider. You are responsible for informing participants.`;
 
@@ -581,6 +589,7 @@ export async function signProntoExecutable(
 ): Promise<void> {
   const signature = await runner("/usr/bin/codesign", [
     "--force",
+    ...(signingIdentity === "-" ? [] : ["--options", "runtime", "--timestamp"]),
     "--sign",
     signingIdentity,
     "--identifier",
@@ -607,6 +616,7 @@ export async function signProntoExecutable(
 export interface SetupDependencies {
   buildExecutable: (outputPath: string) => Promise<void>;
   installAgent: (input: { plist: string; plistPath: string }) => Promise<void>;
+  installUpdater?: (input: { plist: string; plistPath: string }) => Promise<void>;
   saveConfiguration?: (path: string, config: ProntoConfig) => Promise<void>;
 }
 
@@ -648,6 +658,7 @@ export async function installSetup(input: {
           ? executableBuild(process.execPath)
           : sourceBuild(input.repositoryRoot),
       installAgent: installLaunchAgent,
+      installUpdater: installUpdaterLaunchAgent,
     } satisfies SetupDependencies);
   const binDirectory = join(input.paths.appSupportDirectory, "bin");
   await ensurePrivateDirectory(binDirectory);
@@ -691,6 +702,13 @@ export async function installSetup(input: {
       }),
       plistPath: input.paths.launchAgentPath,
     });
+    await dependencies.installUpdater?.({
+      plist: renderUpdaterLaunchAgent({
+        executablePath: input.paths.executablePath,
+        logPath: input.paths.logPath,
+      }),
+      plistPath: input.paths.updaterLaunchAgentPath,
+    });
     await unlink(join(binDirectory, "s4imsg")).catch((error: NodeJS.ErrnoException) => {
       if (error.code !== "ENOENT") throw error;
     });
@@ -704,8 +722,16 @@ export async function uninstallInstallation(input: {
   paths: ProntoPaths;
   purge?: boolean;
   removeAgent?: (plistPath: string) => Promise<void>;
+  removeUpdaterAgent?: (plistPath: string) => Promise<void>;
 }): Promise<void> {
   await (input.removeAgent ?? removeLaunchAgent)(input.paths.launchAgentPath);
+  const removeUpdater = input.removeUpdaterAgent ?? (input.removeAgent === undefined
+    ? (plistPath: string) => removeLaunchAgentForLabel({
+        label: UPDATER_LAUNCH_AGENT_LABEL,
+        plistPath,
+      })
+    : async () => undefined);
+  await removeUpdater(input.paths.updaterLaunchAgentPath);
   await unlink(input.paths.executablePath).catch((error: NodeJS.ErrnoException) => {
     if (error.code !== "ENOENT") throw error;
   });
@@ -765,6 +791,17 @@ export async function inspectInstallation(
           status: "failed",
         },
   );
+
+  if (process.platform === "darwin" && executableReady) {
+    const releaseIdentity = await inspectProntoExecutableIdentity(paths.executablePath, runner);
+    checks.push(releaseIdentity === undefined
+      ? {
+          id: "release-identity",
+          remediation: "Install the official signed release with pronto update --migrate-signing; one final Full Disk Access re-grant is required.",
+          status: "degraded",
+        }
+      : { id: "release-identity", status: "ok" });
+  }
 
   for (const [id, executable] of [
     ["imsg-command", config.imsgPath],

--- a/packages/cli/src/update.ts
+++ b/packages/cli/src/update.ts
@@ -17,15 +17,22 @@ import {
 } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import packageJson from "../../../package.json" with { type: "json" };
-import { atomicWritePrivate, ensurePrivateDirectory, loadConfig, saveConfig } from "./config";
+import {
+  atomicWritePrivate,
+  ensurePrivateDirectory,
+  loadConfig,
+  saveConfig,
+  type ProntoConfig,
+} from "./config";
 import {
   LAUNCH_AGENT_LABEL,
   type ProntoPaths,
 } from "./macos/paths";
 import {
+  installLaunchAgent,
   installUpdaterLaunchAgent,
+  renderLaunchAgent,
   renderUpdaterLaunchAgent,
-  restoreLaunchAgentForLabel,
   stopLaunchAgentForLabel,
 } from "./macos/launch-agent";
 import { runCommand, sha256File, type CommandRunner } from "./macos/setup";
@@ -109,8 +116,8 @@ export interface ProntoUpdateDependencies {
     path: string,
     run: CommandRunner,
   ) => Promise<{ readonly identifier: string; readonly teamIdentifier: string } | undefined>;
+  readonly installMainAgent: (paths: ProntoPaths, config: ProntoConfig) => Promise<void>;
   readonly installUpdaterAgent: (paths: ProntoPaths) => Promise<void>;
-  readonly restoreAgent: (paths: ProntoPaths) => Promise<void>;
   readonly stopAgent: () => Promise<void>;
   readonly verifyEnvelope: (encoded: Uint8Array, now: Date) => ProntoUpdateManifest;
   readonly wait: (milliseconds: number) => Promise<void>;
@@ -123,16 +130,23 @@ const defaultDependencies: ProntoUpdateDependencies = {
   randomId: randomUUID,
   run: runCommand,
   inspectIdentity: inspectProntoExecutableIdentity,
+  installMainAgent: async (paths, config) => await installLaunchAgent({
+    plist: renderLaunchAgent({
+      executablePath: paths.executablePath,
+      logPath: paths.logPath,
+      runtimeExecutablePaths: [
+        config.primaryRuntimePath,
+        config.fallbackRuntimePath,
+      ].filter((path): path is string => path !== undefined),
+    }),
+    plistPath: paths.launchAgentPath,
+  }),
   installUpdaterAgent: async (paths) => await installUpdaterLaunchAgent({
     plist: renderUpdaterLaunchAgent({
       executablePath: paths.executablePath,
       logPath: paths.logPath,
     }),
     plistPath: paths.updaterLaunchAgentPath,
-  }),
-  restoreAgent: async (paths) => await restoreLaunchAgentForLabel({
-    label: LAUNCH_AGENT_LABEL,
-    plistPath: paths.launchAgentPath,
   }),
   stopAgent: async () => await stopLaunchAgentForLabel({ label: LAUNCH_AGENT_LABEL }),
   verifyEnvelope: verifyProntoUpdateEnvelope,
@@ -459,7 +473,7 @@ export class ProntoUpdater {
           ...config,
           installedExecutableHash: await sha256File(this.paths.executablePath),
         });
-        await this.#dependencies.restoreAgent(this.paths);
+        await this.#dependencies.installMainAgent(this.paths, config);
 
         let qualified = false;
         for (let attempt = 0; attempt < QUALIFICATION_ATTEMPTS; attempt += 1) {
@@ -501,7 +515,7 @@ export class ProntoUpdater {
           await saveConfig(this.paths.configPath, config).catch((rollbackError) => {
             rollbackErrors.push(rollbackError);
           });
-          await this.#dependencies.restoreAgent(this.paths).catch((rollbackError) => {
+          await this.#dependencies.installMainAgent(this.paths, config).catch((rollbackError) => {
             rollbackErrors.push(rollbackError);
           });
         }
@@ -585,7 +599,7 @@ export class ProntoUpdater {
           installedExecutableHash: await sha256File(this.paths.executablePath),
         });
         await this.#dependencies.installUpdaterAgent(this.paths);
-        await this.#dependencies.restoreAgent(this.paths);
+        await this.#dependencies.installMainAgent(this.paths, config);
         await atomicWritePrivate(this.paths.updateStatePath, `${JSON.stringify({
           schemaVersion: 1,
           highestReleaseSequence: releaseSequenceForVersion(this.#dependencies.currentVersion),
@@ -601,7 +615,7 @@ export class ProntoUpdater {
         await rename(this.paths.executablePath, failedPath).catch(() => undefined);
         await rename(this.paths.updateBackupPath, this.paths.executablePath);
         await saveConfig(this.paths.configPath, config);
-        await this.#dependencies.restoreAgent(this.paths);
+        await this.#dependencies.installMainAgent(this.paths, config);
         await unlink(failedPath).catch(() => undefined);
         throw error;
       }

--- a/packages/cli/src/update.ts
+++ b/packages/cli/src/update.ts
@@ -1,0 +1,623 @@
+import {
+  createHash,
+  createPublicKey,
+  randomUUID,
+  verify as verifySignature,
+} from "node:crypto";
+import {
+  chmod,
+  copyFile,
+  open,
+  readFile,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+  type FileHandle,
+} from "node:fs/promises";
+import { dirname, join } from "node:path";
+import packageJson from "../../../package.json" with { type: "json" };
+import { atomicWritePrivate, ensurePrivateDirectory, loadConfig, saveConfig } from "./config";
+import {
+  LAUNCH_AGENT_LABEL,
+  type ProntoPaths,
+} from "./macos/paths";
+import {
+  installUpdaterLaunchAgent,
+  renderUpdaterLaunchAgent,
+  restoreLaunchAgentForLabel,
+  stopLaunchAgentForLabel,
+} from "./macos/launch-agent";
+import { runCommand, sha256File, type CommandRunner } from "./macos/setup";
+import {
+  inspectProntoExecutableIdentity,
+  PRONTO_SIGNING_IDENTIFIER,
+  PRONTO_SIGNING_TEAM_IDENTIFIER,
+} from "./macos/release-identity";
+export {
+  inspectProntoExecutableIdentity,
+  PRONTO_SIGNING_IDENTIFIER,
+  PRONTO_SIGNING_TEAM_IDENTIFIER,
+} from "./macos/release-identity";
+export const PRONTO_UPDATE_KEY_ID = "pronto-release-v1";
+export const PRONTO_UPDATE_MANIFEST_URL =
+  "https://github.com/eabnelson/pronto/releases/latest/download/pronto-update.json";
+export const PRONTO_UPDATE_PUBLIC_KEY_SPKI_DER_BASE64 =
+  "MCowBQYDK2VwAyEAN/cWzdaYzwlR5qCKfu4BG5blHXBkd0Hp5mP8x05FrqI=";
+
+const MAX_ENVELOPE_BYTES = 64 * 1_024;
+const MAX_ARTIFACT_BYTES = 256 * 1_024 * 1_024;
+const UPDATE_TIMEOUT_MS = 30_000;
+const QUALIFICATION_ATTEMPTS = 60;
+const QUALIFICATION_INTERVAL_MS = 500;
+
+export type ProntoUpdateTarget = "darwin-arm64" | "darwin-x64";
+
+export interface ProntoUpdateArtifact {
+  readonly url: string;
+  readonly size: number;
+  readonly sha256: string;
+  readonly macosSigning: {
+    readonly identifier: string;
+    readonly teamIdentifier: string;
+  };
+}
+
+export interface ProntoUpdateManifest {
+  readonly schemaVersion: 1;
+  readonly product: "pronto";
+  readonly version: string;
+  readonly releaseSequence: number;
+  readonly channel: "stable";
+  readonly publishedAt: string;
+  readonly expiresAt: string;
+  readonly sourceRevision: string;
+  readonly minimumUpdaterVersion: string;
+  readonly artifacts: Record<ProntoUpdateTarget, ProntoUpdateArtifact>;
+}
+
+export interface SignedProntoUpdateEnvelope {
+  readonly keyId: string;
+  readonly payload: string;
+  readonly signature: string;
+}
+
+export interface ProntoUpdateState {
+  readonly schemaVersion: 1;
+  readonly highestReleaseSequence: number;
+  readonly installedVersion: string;
+  readonly updatedAt: string;
+}
+
+export type ProntoUpdateCheck =
+  | { readonly status: "current"; readonly version: string }
+  | { readonly status: "available"; readonly manifest: ProntoUpdateManifest };
+
+export type ProntoUpdateInstall =
+  | { readonly status: "current"; readonly version: string }
+  | { readonly status: "installed"; readonly version: string }
+  | { readonly status: "migration_required"; readonly version: string }
+  | { readonly status: "migration_installed"; readonly version: string };
+
+export interface ProntoUpdateDependencies {
+  readonly currentVersion: string;
+  readonly fetch: (url: string, init: RequestInit) => Promise<Response>;
+  readonly now: () => Date;
+  readonly randomId: () => string;
+  readonly run: CommandRunner;
+  readonly inspectIdentity: (
+    path: string,
+    run: CommandRunner,
+  ) => Promise<{ readonly identifier: string; readonly teamIdentifier: string } | undefined>;
+  readonly installUpdaterAgent: (paths: ProntoPaths) => Promise<void>;
+  readonly restoreAgent: (paths: ProntoPaths) => Promise<void>;
+  readonly stopAgent: () => Promise<void>;
+  readonly verifyEnvelope: (encoded: Uint8Array, now: Date) => ProntoUpdateManifest;
+  readonly wait: (milliseconds: number) => Promise<void>;
+}
+
+const defaultDependencies: ProntoUpdateDependencies = {
+  currentVersion: packageJson.version,
+  fetch: (url, init) => globalThis.fetch(url, init),
+  now: () => new Date(),
+  randomId: randomUUID,
+  run: runCommand,
+  inspectIdentity: inspectProntoExecutableIdentity,
+  installUpdaterAgent: async (paths) => await installUpdaterLaunchAgent({
+    plist: renderUpdaterLaunchAgent({
+      executablePath: paths.executablePath,
+      logPath: paths.logPath,
+    }),
+    plistPath: paths.updaterLaunchAgentPath,
+  }),
+  restoreAgent: async (paths) => await restoreLaunchAgentForLabel({
+    label: LAUNCH_AGENT_LABEL,
+    plistPath: paths.launchAgentPath,
+  }),
+  stopAgent: async () => await stopLaunchAgentForLabel({ label: LAUNCH_AGENT_LABEL }),
+  verifyEnvelope: verifyProntoUpdateEnvelope,
+  wait: Bun.sleep,
+};
+
+export function releaseSequenceForVersion(version: string): number {
+  const parsed = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (parsed === null) throw new Error("update_version_invalid");
+  const [major, minor, patch] = parsed.slice(1).map(Number) as [number, number, number];
+  if (major > 8_000 || minor > 999 || patch > 999) {
+    throw new Error("update_version_out_of_range");
+  }
+  return major * 1_000_000_000 + minor * 1_000_000 + patch * 1_000 + 999;
+}
+
+export function compareVersions(left: string, right: string): number {
+  return releaseSequenceForVersion(left) - releaseSequenceForVersion(right);
+}
+
+export function updateTarget(
+  platform: NodeJS.Platform = process.platform,
+  architecture: string = process.arch,
+): ProntoUpdateTarget {
+  if (platform !== "darwin") throw new Error("update_platform_unsupported");
+  if (architecture === "arm64") return "darwin-arm64";
+  if (architecture === "x64") return "darwin-x64";
+  throw new Error("update_architecture_unsupported");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  return actual.length === keys.length && actual.every((key, index) => key === [...keys].sort()[index]);
+}
+
+function validIsoDate(value: unknown): value is string {
+  return typeof value === "string" && Number.isFinite(Date.parse(value));
+}
+
+function parseArtifact(value: unknown, version: string, target: ProntoUpdateTarget): ProntoUpdateArtifact {
+  if (!isRecord(value) || !exactKeys(value, ["macosSigning", "sha256", "size", "url"])) {
+    throw new Error("update_artifact_invalid");
+  }
+  if (
+    typeof value.url !== "string" ||
+    !Number.isSafeInteger(value.size) ||
+    (value.size as number) <= 0 ||
+    (value.size as number) > MAX_ARTIFACT_BYTES ||
+    typeof value.sha256 !== "string" ||
+    !/^[a-f0-9]{64}$/.test(value.sha256) ||
+    !isRecord(value.macosSigning) ||
+    !exactKeys(value.macosSigning, ["identifier", "teamIdentifier"]) ||
+    value.macosSigning.identifier !== PRONTO_SIGNING_IDENTIFIER ||
+    value.macosSigning.teamIdentifier !== PRONTO_SIGNING_TEAM_IDENTIFIER
+  ) {
+    throw new Error("update_artifact_invalid");
+  }
+  const url = new URL(value.url);
+  const expectedPath = `/eabnelson/pronto/releases/download/v${version}/pronto-${target}`;
+  if (url.protocol !== "https:" || url.hostname !== "github.com" || url.pathname !== expectedPath) {
+    throw new Error("update_artifact_origin_invalid");
+  }
+  return {
+    url: value.url,
+    size: value.size as number,
+    sha256: value.sha256,
+    macosSigning: {
+      identifier: PRONTO_SIGNING_IDENTIFIER,
+      teamIdentifier: PRONTO_SIGNING_TEAM_IDENTIFIER,
+    },
+  };
+}
+
+export function verifyProntoUpdateEnvelope(
+  encoded: Uint8Array,
+  now = new Date(),
+  publicKeySpkiDerBase64 = PRONTO_UPDATE_PUBLIC_KEY_SPKI_DER_BASE64,
+): ProntoUpdateManifest {
+  if (encoded.byteLength > MAX_ENVELOPE_BYTES) throw new Error("update_envelope_too_large");
+  let envelopeValue: unknown;
+  try {
+    envelopeValue = JSON.parse(new TextDecoder().decode(encoded));
+  } catch {
+    throw new Error("update_envelope_invalid");
+  }
+  if (
+    !isRecord(envelopeValue) ||
+    !exactKeys(envelopeValue, ["keyId", "payload", "signature"]) ||
+    envelopeValue.keyId !== PRONTO_UPDATE_KEY_ID ||
+    typeof envelopeValue.payload !== "string" ||
+    typeof envelopeValue.signature !== "string"
+  ) {
+    throw new Error("update_envelope_invalid");
+  }
+  const payloadBytes = Buffer.from(envelopeValue.payload, "base64url");
+  const signatureBytes = Buffer.from(envelopeValue.signature, "base64url");
+  const publicKey = createPublicKey({
+    key: Buffer.from(publicKeySpkiDerBase64, "base64"),
+    format: "der",
+    type: "spki",
+  });
+  if (!verifySignature(null, payloadBytes, publicKey, signatureBytes)) {
+    throw new Error("update_signature_invalid");
+  }
+  let payloadValue: unknown;
+  try {
+    payloadValue = JSON.parse(payloadBytes.toString("utf8"));
+  } catch {
+    throw new Error("update_payload_invalid");
+  }
+  const keys = [
+    "artifacts",
+    "channel",
+    "expiresAt",
+    "minimumUpdaterVersion",
+    "product",
+    "publishedAt",
+    "releaseSequence",
+    "schemaVersion",
+    "sourceRevision",
+    "version",
+  ];
+  if (!isRecord(payloadValue) || !exactKeys(payloadValue, keys)) {
+    throw new Error("update_payload_invalid");
+  }
+  if (
+    payloadValue.schemaVersion !== 1 ||
+    payloadValue.product !== "pronto" ||
+    payloadValue.channel !== "stable" ||
+    typeof payloadValue.version !== "string" ||
+    typeof payloadValue.minimumUpdaterVersion !== "string" ||
+    !Number.isSafeInteger(payloadValue.releaseSequence) ||
+    payloadValue.releaseSequence !== releaseSequenceForVersion(payloadValue.version) ||
+    !validIsoDate(payloadValue.publishedAt) ||
+    !validIsoDate(payloadValue.expiresAt) ||
+    typeof payloadValue.sourceRevision !== "string" ||
+    !/^[a-f0-9]{40}$/.test(payloadValue.sourceRevision) ||
+    !isRecord(payloadValue.artifacts) ||
+    !exactKeys(payloadValue.artifacts, ["darwin-arm64", "darwin-x64"])
+  ) {
+    throw new Error("update_payload_invalid");
+  }
+  releaseSequenceForVersion(payloadValue.minimumUpdaterVersion);
+  const publishedAt = Date.parse(payloadValue.publishedAt);
+  const expiresAt = Date.parse(payloadValue.expiresAt);
+  if (publishedAt > now.getTime() + 5 * 60_000 || expiresAt <= now.getTime() || expiresAt <= publishedAt) {
+    throw new Error("update_manifest_expired");
+  }
+  return {
+    schemaVersion: 1,
+    product: "pronto",
+    version: payloadValue.version,
+    releaseSequence: payloadValue.releaseSequence as number,
+    channel: "stable",
+    publishedAt: payloadValue.publishedAt,
+    expiresAt: payloadValue.expiresAt,
+    sourceRevision: payloadValue.sourceRevision,
+    minimumUpdaterVersion: payloadValue.minimumUpdaterVersion,
+    artifacts: {
+      "darwin-arm64": parseArtifact(
+        payloadValue.artifacts["darwin-arm64"],
+        payloadValue.version,
+        "darwin-arm64",
+      ),
+      "darwin-x64": parseArtifact(
+        payloadValue.artifacts["darwin-x64"],
+        payloadValue.version,
+        "darwin-x64",
+      ),
+    },
+  };
+}
+
+async function responseBytes(response: Response, maximum: number): Promise<Uint8Array> {
+  if (!response.ok) throw new Error(`update_download_failed:${response.status}`);
+  const declared = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > maximum) throw new Error("update_download_too_large");
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.byteLength > maximum) throw new Error("update_download_too_large");
+  return bytes;
+}
+
+async function loadState(path: string): Promise<ProntoUpdateState | undefined> {
+  try {
+    const value: unknown = JSON.parse(await readFile(path, "utf8"));
+    if (
+      !isRecord(value) ||
+      value.schemaVersion !== 1 ||
+      !Number.isSafeInteger(value.highestReleaseSequence) ||
+      typeof value.installedVersion !== "string" ||
+      !validIsoDate(value.updatedAt)
+    ) {
+      throw new Error("update_state_invalid");
+    }
+    return value as unknown as ProntoUpdateState;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+async function acquireLock(path: string): Promise<FileHandle> {
+  await ensurePrivateDirectory(dirname(path));
+  try {
+    const handle = await open(path, "wx", 0o600);
+    await handle.writeFile(`${process.pid}\n`);
+    return handle;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      const details = await stat(path).catch(() => undefined);
+      if (details !== undefined && Date.now() - details.mtimeMs > 2 * 60 * 60 * 1_000) {
+        await unlink(path);
+        const handle = await open(path, "wx", 0o600);
+        await handle.writeFile(`${process.pid}\n`);
+        return handle;
+      }
+      throw new Error("update_already_running");
+    }
+    throw error;
+  }
+}
+
+export class ProntoUpdater {
+  readonly #dependencies: ProntoUpdateDependencies;
+
+  constructor(
+    readonly paths: ProntoPaths,
+    dependencies: Partial<ProntoUpdateDependencies> = {},
+  ) {
+    this.#dependencies = { ...defaultDependencies, ...dependencies };
+  }
+
+  async check(): Promise<ProntoUpdateCheck> {
+    const response = await this.#dependencies.fetch(PRONTO_UPDATE_MANIFEST_URL, {
+      headers: { accept: "application/json" },
+      redirect: "follow",
+      signal: AbortSignal.timeout(UPDATE_TIMEOUT_MS),
+    });
+    const manifest = this.#dependencies.verifyEnvelope(
+      await responseBytes(response, MAX_ENVELOPE_BYTES),
+      this.#dependencies.now(),
+    );
+    const state = await loadState(this.paths.updateStatePath);
+    if (
+      state !== undefined &&
+      manifest.releaseSequence < state.highestReleaseSequence
+    ) {
+      throw new Error("update_manifest_replay");
+    }
+    if (compareVersions(this.#dependencies.currentVersion, manifest.minimumUpdaterVersion) < 0) {
+      throw new Error("update_updater_incompatible");
+    }
+    if (compareVersions(manifest.version, this.#dependencies.currentVersion) <= 0) {
+      return { status: "current", version: this.#dependencies.currentVersion };
+    }
+    return { status: "available", manifest };
+  }
+
+  async install(options: { readonly allowIdentityMigration?: boolean } = {}): Promise<ProntoUpdateInstall> {
+    const lock = await acquireLock(this.paths.updateLockPath);
+    let stagedPath: string | undefined;
+    try {
+      const check = await this.check();
+      if (check.status === "current") return check;
+      const manifest = check.manifest;
+      const currentIdentity = await this.#dependencies.inspectIdentity(
+        this.paths.executablePath,
+        this.#dependencies.run,
+      );
+      if (currentIdentity === undefined && options.allowIdentityMigration !== true) {
+        return { status: "migration_required", version: manifest.version };
+      }
+
+      const target = updateTarget();
+      const artifact = manifest.artifacts[target];
+      const response = await this.#dependencies.fetch(artifact.url, {
+        headers: { accept: "application/octet-stream" },
+        redirect: "follow",
+        signal: AbortSignal.timeout(UPDATE_TIMEOUT_MS),
+      });
+      const bytes = await responseBytes(response, Math.min(MAX_ARTIFACT_BYTES, artifact.size));
+      if (bytes.byteLength !== artifact.size) throw new Error("update_artifact_size_mismatch");
+      const digest = createHash("sha256").update(bytes).digest("hex");
+      if (digest !== artifact.sha256) throw new Error("update_artifact_digest_mismatch");
+
+      await ensurePrivateDirectory(this.paths.updateDirectory);
+      stagedPath = join(this.paths.updateDirectory, `.candidate-${this.#dependencies.randomId()}`);
+      await writeFile(stagedPath, bytes, { mode: 0o700 });
+      await chmod(stagedPath, 0o700);
+      const identity = await this.#dependencies.inspectIdentity(stagedPath, this.#dependencies.run);
+      if (
+        identity?.identifier !== artifact.macosSigning.identifier ||
+        identity.teamIdentifier !== artifact.macosSigning.teamIdentifier
+      ) {
+        throw new Error("update_artifact_identity_mismatch");
+      }
+      const version = await this.#dependencies.run(stagedPath, ["--version"]);
+      if (version.exitCode !== 0 || version.stdout.trim() !== `pronto ${manifest.version}`) {
+        throw new Error("update_artifact_version_mismatch");
+      }
+
+      const config = await loadConfig(this.paths.configPath);
+      const backupPath = this.paths.updateBackupPath;
+      await unlink(backupPath).catch((error: NodeJS.ErrnoException) => {
+        if (error.code !== "ENOENT") throw error;
+      });
+      const migrated = currentIdentity === undefined;
+      let previousAtBackup = false;
+      let candidateAtInstalledPath = false;
+      let qualificationFailedDuringMigration = false;
+      try {
+        await this.#dependencies.stopAgent();
+        await rename(this.paths.executablePath, backupPath);
+        previousAtBackup = true;
+        await rename(stagedPath, this.paths.executablePath);
+        candidateAtInstalledPath = true;
+        stagedPath = undefined;
+        await chmod(this.paths.executablePath, 0o700);
+        await saveConfig(this.paths.configPath, {
+          ...config,
+          installedExecutableHash: await sha256File(this.paths.executablePath),
+        });
+        await this.#dependencies.restoreAgent(this.paths);
+
+        let qualified = false;
+        for (let attempt = 0; attempt < QUALIFICATION_ATTEMPTS; attempt += 1) {
+          const status = await this.#dependencies.run(this.paths.executablePath, ["status", "--json"]);
+          if (status.exitCode === 0) {
+            qualified = true;
+            break;
+          }
+          await this.#dependencies.wait(QUALIFICATION_INTERVAL_MS);
+        }
+        if (!qualified) {
+          if (migrated) qualificationFailedDuringMigration = true;
+          else throw new Error("update_candidate_qualification_failed");
+        }
+        await atomicWritePrivate(this.paths.updateStatePath, `${JSON.stringify({
+          schemaVersion: 1,
+          highestReleaseSequence: manifest.releaseSequence,
+          installedVersion: manifest.version,
+          updatedAt: this.#dependencies.now().toISOString(),
+        } satisfies ProntoUpdateState, null, 2)}\n`);
+      } catch (error) {
+        if (migrated && qualificationFailedDuringMigration) {
+          throw error;
+        }
+        const rollbackErrors: unknown[] = [];
+        await this.#dependencies.stopAgent().catch((rollbackError) => {
+          rollbackErrors.push(rollbackError);
+        });
+        const failedPath = join(this.paths.updateDirectory, `.failed-${this.#dependencies.randomId()}`);
+        if (candidateAtInstalledPath) {
+          await rename(this.paths.executablePath, failedPath).catch((rollbackError) => {
+            rollbackErrors.push(rollbackError);
+          });
+        }
+        if (previousAtBackup) {
+          await rename(backupPath, this.paths.executablePath).catch((rollbackError) => {
+            rollbackErrors.push(rollbackError);
+          });
+          await saveConfig(this.paths.configPath, config).catch((rollbackError) => {
+            rollbackErrors.push(rollbackError);
+          });
+          await this.#dependencies.restoreAgent(this.paths).catch((rollbackError) => {
+            rollbackErrors.push(rollbackError);
+          });
+        }
+        await unlink(failedPath).catch(() => undefined);
+        if (rollbackErrors.length > 0) {
+          throw new AggregateError([error, ...rollbackErrors], "update_rollback_failed");
+        }
+        throw error;
+      }
+      return migrated && qualificationFailedDuringMigration
+        ? { status: "migration_installed", version: manifest.version }
+        : { status: "installed", version: manifest.version };
+    } finally {
+      await lock.close();
+      await unlink(this.paths.updateLockPath).catch(() => undefined);
+      if (stagedPath !== undefined) await unlink(stagedPath).catch(() => undefined);
+    }
+  }
+
+  async migrateLocalCandidate(candidatePath: string): Promise<ProntoUpdateInstall> {
+    const lock = await acquireLock(this.paths.updateLockPath);
+    let stagedPath: string | undefined;
+    try {
+      const candidateIdentity = await this.#dependencies.inspectIdentity(
+        candidatePath,
+        this.#dependencies.run,
+      );
+      if (
+        candidateIdentity?.identifier !== PRONTO_SIGNING_IDENTIFIER ||
+        candidateIdentity.teamIdentifier !== PRONTO_SIGNING_TEAM_IDENTIFIER
+      ) {
+        throw new Error("update_migration_candidate_identity_invalid");
+      }
+      const candidateVersion = await this.#dependencies.run(candidatePath, ["--version"]);
+      if (
+        candidateVersion.exitCode !== 0 ||
+        candidateVersion.stdout.trim() !== `pronto ${this.#dependencies.currentVersion}`
+      ) {
+        throw new Error("update_migration_candidate_version_invalid");
+      }
+      const installedVersion = await this.#dependencies.run(this.paths.executablePath, ["--version"]);
+      const parsedInstalledVersion = /^pronto (\d+\.\d+\.\d+)$/.exec(
+        installedVersion.stdout.trim(),
+      )?.[1];
+      if (
+        installedVersion.exitCode !== 0 ||
+        parsedInstalledVersion === undefined ||
+        compareVersions(this.#dependencies.currentVersion, parsedInstalledVersion) < 0
+      ) {
+        throw new Error("update_migration_installed_version_invalid");
+      }
+      const existingIdentity = await this.#dependencies.inspectIdentity(
+        this.paths.executablePath,
+        this.#dependencies.run,
+      );
+      if (existingIdentity !== undefined) {
+        return { status: "current", version: parsedInstalledVersion };
+      }
+
+      const config = await loadConfig(this.paths.configPath);
+      await ensurePrivateDirectory(this.paths.updateDirectory);
+      stagedPath = join(this.paths.updateDirectory, `.migration-${this.#dependencies.randomId()}`);
+      await copyFile(candidatePath, stagedPath);
+      await chmod(stagedPath, 0o700);
+      const stagedIdentity = await this.#dependencies.inspectIdentity(
+        stagedPath,
+        this.#dependencies.run,
+      );
+      if (stagedIdentity === undefined) throw new Error("update_migration_copy_identity_invalid");
+
+      await unlink(this.paths.updateBackupPath).catch((error: NodeJS.ErrnoException) => {
+        if (error.code !== "ENOENT") throw error;
+      });
+      await this.#dependencies.stopAgent();
+      await rename(this.paths.executablePath, this.paths.updateBackupPath);
+      try {
+        await rename(stagedPath, this.paths.executablePath);
+        stagedPath = undefined;
+        await saveConfig(this.paths.configPath, {
+          ...config,
+          installedExecutableHash: await sha256File(this.paths.executablePath),
+        });
+        await this.#dependencies.installUpdaterAgent(this.paths);
+        await this.#dependencies.restoreAgent(this.paths);
+        await atomicWritePrivate(this.paths.updateStatePath, `${JSON.stringify({
+          schemaVersion: 1,
+          highestReleaseSequence: releaseSequenceForVersion(this.#dependencies.currentVersion),
+          installedVersion: this.#dependencies.currentVersion,
+          updatedAt: this.#dependencies.now().toISOString(),
+        } satisfies ProntoUpdateState, null, 2)}\n`);
+      } catch (error) {
+        await this.#dependencies.stopAgent().catch(() => undefined);
+        const failedPath = join(
+          this.paths.updateDirectory,
+          `.failed-migration-${this.#dependencies.randomId()}`,
+        );
+        await rename(this.paths.executablePath, failedPath).catch(() => undefined);
+        await rename(this.paths.updateBackupPath, this.paths.executablePath);
+        await saveConfig(this.paths.configPath, config);
+        await this.#dependencies.restoreAgent(this.paths);
+        await unlink(failedPath).catch(() => undefined);
+        throw error;
+      }
+
+      for (let attempt = 0; attempt < QUALIFICATION_ATTEMPTS; attempt += 1) {
+        const status = await this.#dependencies.run(this.paths.executablePath, ["status", "--json"]);
+        if (status.exitCode === 0) {
+          return { status: "installed", version: this.#dependencies.currentVersion };
+        }
+        await this.#dependencies.wait(QUALIFICATION_INTERVAL_MS);
+      }
+      return { status: "migration_installed", version: this.#dependencies.currentVersion };
+    } finally {
+      await lock.close();
+      await unlink(this.paths.updateLockPath).catch(() => undefined);
+      if (stagedPath !== undefined) await unlink(stagedPath).catch(() => undefined);
+    }
+  }
+}

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-imessage",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "Reusable local Apple Messages transport for Pronto consumers",
   "type": "module",
   "license": "MIT",

--- a/scripts/generate-update-manifest.ts
+++ b/scripts/generate-update-manifest.ts
@@ -1,0 +1,71 @@
+import { createHash, createPrivateKey, sign } from "node:crypto";
+import { readFile, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  PRONTO_SIGNING_IDENTIFIER,
+  PRONTO_SIGNING_TEAM_IDENTIFIER,
+  PRONTO_UPDATE_KEY_ID,
+  releaseSequenceForVersion,
+  type ProntoUpdateArtifact,
+  type ProntoUpdateManifest,
+  type ProntoUpdateTarget,
+  type SignedProntoUpdateEnvelope,
+} from "../packages/cli/src/update";
+
+function required(name: string): string {
+  const value = process.env[name]?.trim();
+  if (value === undefined || value === "") throw new Error(`${name} is required`);
+  return value;
+}
+
+const directory = required("PRONTO_RELEASE_DIRECTORY");
+const version = required("PRONTO_RELEASE_VERSION");
+const revision = required("PRONTO_RELEASE_REVISION");
+const publishedAt = new Date(required("PRONTO_RELEASE_PUBLISHED_AT"));
+const privateKeyPem = required("PRONTO_RELEASE_ED25519_PRIVATE_KEY");
+if (!/^[a-f0-9]{40}$/.test(revision)) throw new Error("release revision must be a full commit SHA");
+if (!Number.isFinite(publishedAt.getTime())) throw new Error("release publication time is invalid");
+const expiresAt = new Date(publishedAt.getTime() + 366 * 24 * 60 * 60 * 1_000);
+
+async function artifact(target: ProntoUpdateTarget): Promise<ProntoUpdateArtifact> {
+  const name = `pronto-${target}`;
+  const path = join(directory, name);
+  const [bytes, details] = await Promise.all([readFile(path), stat(path)]);
+  if (!details.isFile() || details.size <= 0) throw new Error(`release artifact is invalid: ${name}`);
+  return {
+    url: `https://github.com/eabnelson/pronto/releases/download/v${version}/${name}`,
+    size: details.size,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    macosSigning: {
+      identifier: PRONTO_SIGNING_IDENTIFIER,
+      teamIdentifier: PRONTO_SIGNING_TEAM_IDENTIFIER,
+    },
+  };
+}
+
+const payload: ProntoUpdateManifest = {
+  schemaVersion: 1,
+  product: "pronto",
+  version,
+  releaseSequence: releaseSequenceForVersion(version),
+  channel: "stable",
+  publishedAt: publishedAt.toISOString(),
+  expiresAt: expiresAt.toISOString(),
+  sourceRevision: revision,
+  minimumUpdaterVersion: "0.3.0",
+  artifacts: {
+    "darwin-arm64": await artifact("darwin-arm64"),
+    "darwin-x64": await artifact("darwin-x64"),
+  },
+};
+const payloadBytes = Buffer.from(JSON.stringify(payload));
+const signature = sign(null, payloadBytes, createPrivateKey(privateKeyPem));
+const envelope: SignedProntoUpdateEnvelope = {
+  keyId: PRONTO_UPDATE_KEY_ID,
+  payload: payloadBytes.toString("base64url"),
+  signature: signature.toString("base64url"),
+};
+await writeFile(join(directory, "pronto-update.json"), `${JSON.stringify(envelope)}\n`, {
+  encoding: "utf8",
+  mode: 0o600,
+});

--- a/scripts/release-workflow-validation.ts
+++ b/scripts/release-workflow-validation.ts
@@ -7,11 +7,17 @@ const REQUIRED_CONTROLS = [
   ["npm install --global npm@11.19.1", "trusted-publishing npm CLI"],
   ['test "$(npm --version)" = "11.19.1"', "trusted-publishing npm CLI verification"],
   ["for ATTEMPT in {1..60}; do", "npm registry propagation retry"],
-  ["dist/pronto-imessage-*.tgz", "package release artifact"],
+  ["release/pronto-imessage-*.tgz", "package release artifact"],
   ["sha256sum -c pronto-imessage.sha256", "downloaded package checksum verification"],
+  ["environment: release", "protected release environment"],
+  ["codesign --force --options runtime --timestamp", "Developer ID hardened-runtime signing"],
+  ["xcrun notarytool submit", "Apple notarization"],
+  ["PRONTO_RELEASE_ED25519_PRIVATE_KEY", "signed update manifest credential"],
+  ["bun scripts/generate-update-manifest.ts", "signed update manifest generation"],
+  ["actions/attest-build-provenance@", "artifact provenance attestation"],
   ["workflow_dispatch:", "manual immutable-tag recovery"],
   [
-    "ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.ref }}",
+    "ref: ${{ github.ref }}",
     "tag-pinned recovery checkout",
   ],
   [
@@ -22,7 +28,7 @@ const REQUIRED_CONTROLS = [
 
 const ORDERED_STEPS = [
   "- name: Verify owner qualification is complete",
-  "- name: Create and verify checksum",
+  "- name: Create signed update manifest and checksums",
   "\n  publish:",
   "- name: Verify downloaded checksum",
   "- name: Create draft release",

--- a/site/setup.md
+++ b/site/setup.md
@@ -1,18 +1,29 @@
 # Set up pronto for me
 
-You are my setup agent. Help me install and verify **pronto**, the local macOS bridge that lets tags in iMessage or RCS chats invoke Codex or Claude Code.
+You are my setup agent. Help me install and verify **pronto**, the local macOS
+bridge that lets explicit tags in iMessage or RCS chats invoke Codex or Claude
+Code.
 
-Repository: <https://github.com/eabnelson/pronto>
+Official repository: <https://github.com/eabnelson/pronto>
 
-Work interactively and stay with me until one tagged iMessage or RCS message gets exactly one agent reply. Explain what you are checking, run the terminal steps you can run, and pause only when I must choose an option or change a macOS setting.
+Work interactively and stay with me until one tagged iMessage or RCS message
+gets exactly one agent reply. Explain what you are checking, run the terminal
+steps you can run, and pause only when I must choose an option or change a
+macOS setting.
 
 ## Safety rules
 
-- This works only on macOS with Messages signed in to iMessage. RCS also requires an iPhone and carrier configuration that makes the conversation available in Messages on the Mac. SMS messages do not activate Pronto.
-- Do not use `sudo`, disable System Integrity Protection, or enable a private IMCore bridge.
-- Do not type `yes` for me at the trust-model prompt. Show me the warning, let me read it, and ask me to type my own answer.
-- Never paste or record real message text, phone numbers, email addresses, chat identifiers, attachment paths, credentials, or provider output.
-- Do not weaken the repository's permission, privacy, or release checks.
+- This works only on macOS with Messages signed in to iMessage. RCS also
+  requires an iPhone and carrier configuration that makes the conversation
+  available in Messages on the Mac. SMS messages do not activate Pronto.
+- Do not use `sudo`, disable System Integrity Protection, enable a private
+  IMCore bridge, or install an unsigned/ad-hoc Pronto build.
+- Do not type `yes` for me at the trust-model prompt. Show me the warning, let
+  me read it, and ask me to type my own answer.
+- Never paste or record real message text, phone numbers, email addresses, chat
+  identifiers, attachment paths, credentials, or provider output.
+- Do not weaken the repository's permission, privacy, signature, or update
+  checks.
 
 ## Walk me through this
 
@@ -20,92 +31,91 @@ Work interactively and stay with me until one tagged iMessage or RCS message get
 
    ```sh
    sw_vers
-   git --version
-   bun --version
    imsg --version
    codex --version
    claude --version
    ```
 
-   I need Bun 1.3.14 or newer, `imsg` 0.14 or a capability-compatible version, and at least one authenticated Codex CLI or Claude Code CLI. A missing optional runtime is fine. If Bun or `imsg` is missing and Homebrew is installed, offer:
+   I need `imsg` 0.15.0 and at least one authenticated Codex CLI or Claude Code
+   CLI. A missing optional runtime is fine. If `imsg` is missing and Homebrew is
+   installed, offer:
 
    ```sh
-   brew install oven-sh/bun/bun steipete/tap/imsg
+   brew install steipete/tap/imsg
    ```
 
-   If neither Codex nor Claude Code is installed and authenticated, stop and help me install and sign in to the one I choose before continuing.
+   If neither Codex nor Claude Code is installed and authenticated, stop and
+   help me install and sign in to the one I choose before continuing.
 
-2. Ask where I want the source checkout. Suggest `~/Developer/pronto`, resolve my answer to an absolute path, and use that exact path as `CHECKOUT`. Never leave the example value below unchanged.
-
-   If the chosen path does not exist or is an empty directory, create a new checkout. Run this as one shell call after replacing the first value with the absolute path I chose:
-
-   ```sh
-   CHECKOUT="/absolute/path/I/chose"
-   git clone https://github.com/eabnelson/pronto.git "$CHECKOUT"
-   cd "$CHECKOUT"
-   ```
-
-   If the chosen path already contains files, do not overwrite it. Reuse it only when it is a Git checkout whose origin is exactly `https://github.com/eabnelson/pronto.git` or `git@github.com:eabnelson/pronto.git` and whose worktree is clean. Run these checks and the update as one shell call after replacing the first value with the absolute path I chose:
+2. Download the official binary for this Mac into a new temporary directory.
+   Run this exact guarded shell block. Do not replace its URL, signing
+   identifier, Team ID, or requirement:
 
    ```sh
-   CHECKOUT="/absolute/path/I/chose"
-   cd "$CHECKOUT" || exit 1
-   ORIGIN="$(git remote get-url origin)" || exit 1
-   case "$ORIGIN" in
-     https://github.com/eabnelson/pronto.git|git@github.com:eabnelson/pronto.git) ;;
-     *) echo "Stop: the existing checkout does not have the official pronto origin." >&2; exit 1 ;;
+   PRONTO_INSTALL_DIR="$(mktemp -d)" || exit 1
+   case "$(uname -m)" in
+     arm64) PRONTO_TARGET="darwin-arm64" ;;
+     x86_64) PRONTO_TARGET="darwin-x64" ;;
+     *) echo "Unsupported Mac architecture" >&2; exit 1 ;;
    esac
-   if [ -n "$(git status --porcelain)" ]; then
-     echo "Stop: the existing checkout has local changes." >&2
-     exit 1
-   fi
-   git pull --ff-only
+   PRONTO_CANDIDATE="$PRONTO_INSTALL_DIR/pronto"
+   curl --fail --location --proto '=https' --tlsv1.2 \
+     "https://github.com/eabnelson/pronto/releases/latest/download/pronto-$PRONTO_TARGET" \
+     --output "$PRONTO_CANDIDATE" || exit 1
+   chmod 700 "$PRONTO_CANDIDATE" || exit 1
+   codesign --verify --strict \
+     -R='identifier "dev.pronto.cli" and anchor apple generic and certificate leaf[subject.OU] = "9YCNUWK84C"' \
+     "$PRONTO_CANDIDATE" || exit 1
+   "$PRONTO_CANDIDATE" --version
    ```
 
-   If any guard fails, stop and ask me to choose a fresh, empty directory. Only after the new clone or guarded update succeeds, install dependencies from the chosen checkout in one shell call:
+   Stop if downloading, signature verification, or the version command fails.
+   Never fall back to building from source for an ordinary installation.
+
+3. Before running setup, guide me to **System Settings → Privacy & Security →
+   Full Disk Access** and have me enable the terminal or parent app that will run setup.
+   This lets setup perform its temporary Messages database preflight.
+   Then run the signed candidate:
 
    ```sh
-   CHECKOUT="/absolute/path/I/chose"
-   cd "$CHECKOUT" || exit 1
-   bun install --frozen-lockfile
+   "$PRONTO_CANDIDATE" setup
    ```
 
-3. Before running setup, guide me to **System Settings → Privacy & Security → Full Disk Access** and have me enable the terminal or parent app that will run setup. This access is required for setup to inspect the local Messages database. Then start the interactive setup from the chosen checkout:
+   Help me choose one or more trigger tags, a primary runtime, an optional
+   fallback, and a default working folder. Explain that the working folder is
+   context, not a security boundary. At the trust-model prompt, stop and let me
+   personally decide whether to type `yes`.
 
-   ```sh
-   CHECKOUT="/absolute/path/I/chose"
-   cd "$CHECKOUT" || exit 1
-   bun run packages/cli/src/cli.ts setup
-   ```
-
-   Help me choose:
-
-   - one or more comma-separated trigger tags, with or without `@`;
-   - a primary runtime;
-   - an optional fallback runtime;
-   - a default working folder, normally `~/pronto`.
-
-   Explain that the working folder is context, not a security boundary. At the trust-model prompt, stop and let me personally decide whether to type `yes`.
-
-4. When setup finishes, guide me to **System Settings → Privacy & Security → Full Disk Access**. I must add and enable this exact installed executable:
+4. When setup asks, guide me to **System Settings → Privacy & Security → Full
+   Disk Access**. I must add and enable this exact installed executable:
 
    ```text
    ~/Library/Application Support/pronto/bin/pronto
    ```
 
-   If a stale pronto entry already exists, have me remove it and add the exact file again. Messages may also ask me to approve Automation on the first real reply.
+   If a stale Pronto entry exists, remove it and add the exact file again.
+   Messages may also ask me to approve Automation on the first real reply.
+   After setup finishes, remove only the temporary candidate:
 
-5. Run the installed diagnostics with a safely quoted path and wait for the runtime probes to finish:
+   ```sh
+   unlink "$PRONTO_CANDIDATE"
+   rmdir "$PRONTO_INSTALL_DIR"
+   ```
+
+5. Run the installed diagnostics and wait for runtime probes to finish:
 
    ```sh
    PRONTO="$HOME/Library/Application Support/pronto/bin/pronto"
    "$PRONTO" doctor
    "$PRONTO" status
+   "$PRONTO" update --check
    ```
 
-   A healthy service reports `listener running`, `database ready`, and `daemon ready`. Resolve failed checks before continuing. A send-automation check may stay degraded until the first real reply.
+   A healthy service reports `listener running`, `database ready`, and `daemon
+   ready`. Resolve failed checks before continuing. A send-automation check may
+   stay degraded until the first real reply.
 
-6. Show me how to manage tags from the installed CLI:
+6. Show me how to manage tags:
 
    ```sh
    PRONTO="$HOME/Library/Application Support/pronto/bin/pronto"
@@ -114,15 +124,26 @@ Work interactively and stay with me until one tagged iMessage or RCS message get
    "$PRONTO" tags remove @plan
    ```
 
-   Explain that tags are case-insensitive, duplicate tags are ignored, and at least one tag must remain. If a message contains two different configured tags, the bridge ignores it instead of choosing ambiguously. Then ask me to send `<my-tag> ping` in an iMessage or RCS conversation where this Mac owner has already sent at least one message. Confirm that exactly one agent reply arrives. SMS does not activate Pronto. In a self-chat, Messages may display each single send as an incoming/outgoing mirrored pair; that is one send, not a duplicate.
+   Explain that tags are case-insensitive, duplicate tags are ignored, and at
+   least one tag must remain. If a message contains two configured tags, Pronto
+   ignores it instead of choosing ambiguously. Then ask me to send `<my-tag>
+   ping` in an iMessage or RCS conversation where this Mac owner has already
+   sent a message. Confirm that exactly one agent reply arrives. SMS does not
+   activate Pronto.
 
-7. Run the final status check with its executable assigned in the same shell call:
+7. Run the final self-contained status check:
 
    ```sh
    PRONTO="$HOME/Library/Application Support/pronto/bin/pronto"
    "$PRONTO" status
    ```
 
-   Finish with a short summary of my tags, primary and fallback runtimes, default working folder, installed executable, and whether the listener, database, and daemon are ready. Do not include conversation or participant data.
+   Finish with a short summary of my tags, runtimes, working folder, installed
+   executable, update status, and listener health. Do not include conversation
+   or participant data. Explain that the signed updater checks automatically
+   every six hours and future updates do not rerun setup or require another FDA
+   grant as long as the stable signing identity is unchanged.
 
-If anything fails, use the repository's `README.md`, `SECURITY.md`, and `docs/LIVE_SMOKE.md` as the source of truth and keep troubleshooting with me.
+If anything fails, use the repository's `README.md`, `SECURITY.md`,
+`docs/UPDATES.md`, and `docs/LIVE_SMOKE.md` as the source of truth and keep
+troubleshooting with me.

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -36,7 +36,7 @@ describe("Pronto CLI", () => {
     ]);
 
     expect(exitCode).toBe(0);
-    expect(stdout.trim()).toBe("pronto 0.2.4");
+    expect(stdout.trim()).toBe("pronto 0.3.0");
   });
 
   test("the legacy command explains the rename and delegates safe commands", async () => {
@@ -54,7 +54,7 @@ describe("Pronto CLI", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr.trim()).toBe("s4imsg is now Pronto; use the pronto command.");
-    expect(stdout.trim()).toBe("pronto 0.2.4");
+    expect(stdout.trim()).toBe("pronto 0.3.0");
   });
 
   test("the legacy command refuses to start a second foreground listener", async () => {

--- a/test/unit/launch-agent.test.ts
+++ b/test/unit/launch-agent.test.ts
@@ -4,9 +4,11 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   installLaunchAgent,
+  installUpdaterLaunchAgent,
   parseLaunchAgentState,
   removeLaunchAgentForLabel,
   renderLaunchAgent,
+  renderUpdaterLaunchAgent,
   restoreLaunchAgentForLabel,
   restartLaunchAgent,
   stopLaunchAgentForLabel,
@@ -38,6 +40,21 @@ test("renders a stable owner LaunchAgent without shell interpolation", () => {
   expect(plist).toContain(
     "<string>/opt/homebrew/bin:/Users/me/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>",
   );
+  expect(plist).not.toContain("/bin/sh");
+});
+
+test("renders a bounded periodic updater without a keepalive loop", () => {
+  const plist = renderUpdaterLaunchAgent({
+    executablePath: "/Users/me/Application Support/pronto/bin/pronto",
+    logPath: "/Users/me/Logs/pronto/daemon.log",
+  });
+
+  expect(plist).toContain("dev.pronto.updater");
+  expect(plist).toContain("<string>update</string>");
+  expect(plist).toContain("<string>--automatic</string>");
+  expect(plist).toContain("<integer>21600</integer>");
+  expect(plist).not.toContain("<key>RunAtLoad</key>");
+  expect(plist).not.toContain("<key>KeepAlive</key>");
   expect(plist).not.toContain("/bin/sh");
 });
 
@@ -178,6 +195,33 @@ test("installs and bootstraps one LaunchAgent", async () => {
     ["print", "gui/501/dev.pronto.agent"],
     ["bootstrap", "gui/501", plistPath],
     ["kickstart", "-k", "gui/501/dev.pronto.agent"],
+  ]);
+});
+
+test("installs the periodic updater without immediately kickstarting it", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "pronto-updater-agent-"));
+  temporaryDirectories.push(directory);
+  const plistPath = join(directory, "dev.pronto.updater.plist");
+  const calls: string[][] = [];
+
+  await installUpdaterLaunchAgent({
+    plist: "<?xml version=\"1.0\"?><plist></plist>\n",
+    plistPath,
+    runner: async (args) => {
+      calls.push([...args]);
+      return {
+        exitCode: args[0] === "bootout" || args[0] === "print" ? 3 : 0,
+        stderr: "",
+        stdout: "",
+      };
+    },
+    uid: 501,
+  });
+
+  expect(calls).toEqual([
+    ["bootout", "gui/501/dev.pronto.updater"],
+    ["print", "gui/501/dev.pronto.updater"],
+    ["bootstrap", "gui/501", plistPath],
   ]);
 });
 

--- a/test/unit/paths.test.ts
+++ b/test/unit/paths.test.ts
@@ -11,6 +11,11 @@ test("derives one owner-scoped service layout", () => {
     logDirectory: "/Users/example/Library/Logs/pronto",
     logPath: "/Users/example/Library/Logs/pronto/daemon.log",
     providerStatePath: "/Users/example/Library/Application Support/pronto/provider-state.json",
+    updateBackupPath: "/Users/example/Library/Application Support/pronto/updates/last-known-good",
+    updateDirectory: "/Users/example/Library/Application Support/pronto/updates",
+    updateLockPath: "/Users/example/Library/Application Support/pronto/updates/update.lock",
+    updateStatePath: "/Users/example/Library/Application Support/pronto/updates/state.json",
+    updaterLaunchAgentPath: "/Users/example/Library/LaunchAgents/dev.pronto.updater.plist",
   });
 });
 
@@ -24,5 +29,10 @@ test("retains the legacy layout only for migration", () => {
     logDirectory: "/Users/example/Library/Logs/s4imsg",
     logPath: "/Users/example/Library/Logs/s4imsg/daemon.log",
     providerStatePath: "/Users/example/Library/Application Support/s4imsg/provider-state.json",
+    updateBackupPath: "/Users/example/Library/Application Support/s4imsg/updates/last-known-good",
+    updateDirectory: "/Users/example/Library/Application Support/s4imsg/updates",
+    updateLockPath: "/Users/example/Library/Application Support/s4imsg/updates/update.lock",
+    updateStatePath: "/Users/example/Library/Application Support/s4imsg/updates/state.json",
+    updaterLaunchAgentPath: "/Users/example/Library/LaunchAgents/dev.s4imsg.agent.updater.plist",
   });
 });

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -22,10 +22,14 @@ describe("release workflow", () => {
     expect(beforePublish).toContain(".draft == true");
     expect(beforePublish).toContain('([.assets[].name] | sort) == ([');
     expect(beforePublish).toContain('$package');
-    expect(workflow).toContain("codesign --verify --strict --verbose=4 dist/pronto");
+    expect(workflow).toContain("codesign --verify --strict --verbose=4 -R=\"$requirement\"");
+    expect(workflow).toContain("codesign --force --options runtime --timestamp");
+    expect(workflow).toContain("xcrun notarytool submit");
+    expect(workflow).toContain("environment: release");
+    expect(workflow).toContain("pronto-update.json");
     expect(workflow).not.toContain("dist/s4imsg");
     expect(workflow).not.toContain("release-assets/s4imsg");
-    expect(workflow).toContain("dist/pronto-imessage-*.tgz");
+    expect(workflow).toContain("release/pronto-imessage-*.tgz");
   });
 
   test("keeps releases immutable and verifies the published release", async () => {
@@ -63,10 +67,10 @@ describe("release workflow", () => {
       "npm install --global npm@11.19.1",
       'test "$(npm --version)" = "11.19.1"',
       "for ATTEMPT in {1..60}; do",
-      "dist/pronto-imessage-*.tgz",
+      "release/pronto-imessage-*.tgz",
       "sha256sum -c pronto-imessage.sha256",
       "workflow_dispatch:",
-      "ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.ref }}",
+      "ref: ${{ github.ref }}",
       'git rev-parse "refs/tags/$RELEASE_TAG^{commit}"',
     ]) {
       expect(releaseWorkflowViolations(workflow.replace(control, "removed-control")))
@@ -93,15 +97,13 @@ describe("release workflow", () => {
   test("manual recovery rebuilds an explicit immutable tag", async () => {
     const workflow = await releaseWorkflow();
 
-    expect(workflow).toContain("release_tag:");
-    expect(workflow).toContain("RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}");
-    expect(workflow).toContain(
-      "ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.ref }}",
-    );
-    expect(workflow).toContain("Verify recovery checkout is the immutable tag");
+    expect(workflow).toContain("RELEASE_TAG: ${{ github.ref_name }}");
+    expect(workflow).toContain("ref: ${{ github.ref }}");
+    expect(workflow).toContain("Verify immutable tag and package version");
     expect(workflow).toContain('git rev-parse "refs/tags/$RELEASE_TAG^{commit}"');
     expect(workflow).toContain('test "v$VERSION" = "$RELEASE_TAG"');
-    expect(workflow).toContain('echo "release-tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"');
+    expect(workflow).toContain('echo "release-tag=$RELEASE_TAG"');
+    expect(workflow).toContain('} >> "$GITHUB_OUTPUT"');
     expect(workflow).toContain("RELEASE_TAG: ${{ needs.build.outputs.release-tag }}");
     expect(workflow).toContain('--title "Pronto $RELEASE_TAG"');
     expect(workflow).not.toContain("$GITHUB_REF_NAME");

--- a/test/unit/setup.test.ts
+++ b/test/unit/setup.test.ts
@@ -289,6 +289,7 @@ test("setup atomically installs a hashed executable and private configuration", 
   await mkdir(join(paths.appSupportDirectory, "bin"), { recursive: true });
   await writeFile(compatibilityExecutable, "obsolete-shim", { mode: 0o700 });
   let installedPlist = "";
+  let installedUpdaterPlist = "";
 
   const installed = await installSetup({
     config: prepareSetupConfig({
@@ -307,6 +308,9 @@ test("setup atomically installs a hashed executable and private configuration", 
       installAgent: async ({ plist }) => {
         installedPlist = plist;
       },
+      installUpdater: async ({ plist }) => {
+        installedUpdaterPlist = plist;
+      },
     },
     paths,
   });
@@ -316,6 +320,8 @@ test("setup atomically installs a hashed executable and private configuration", 
   await expect(access(compatibilityExecutable)).rejects.toThrow();
   expect(installed.installedExecutableHash).toHaveLength(64);
   expect(installedPlist).toContain(paths.executablePath);
+  expect(installedUpdaterPlist).toContain("dev.pronto.updater");
+  expect(installedUpdaterPlist).toContain("--automatic");
   expect(await readFile(paths.configPath, "utf8")).not.toContain("@Helper");
 });
 
@@ -695,6 +701,9 @@ test("source builds replace Bun's embedded signature before installation", async
       executable: "/usr/bin/codesign",
       args: [
         "--force",
+        "--options",
+        "runtime",
+        "--timestamp",
         "--sign",
         "Developer ID Application: Example",
         "--identifier",
@@ -1114,15 +1123,20 @@ test("uninstall removes the service executable but retains private data by defau
   await writeFile(paths.configPath, "configuration");
   await writeFile(paths.databasePath, "database");
   let agentRemoved = false;
+  let updaterRemoved = false;
 
   await uninstallInstallation({
     paths,
     removeAgent: async () => {
       agentRemoved = true;
     },
+    removeUpdaterAgent: async () => {
+      updaterRemoved = true;
+    },
   });
 
   expect(agentRemoved).toBeTrue();
+  expect(updaterRemoved).toBeTrue();
   await expect(access(paths.executablePath)).rejects.toThrow();
   expect(await readFile(paths.configPath, "utf8")).toBe("configuration");
   expect(await readFile(paths.databasePath, "utf8")).toBe("database");

--- a/test/unit/site.test.ts
+++ b/test/unit/site.test.ts
@@ -503,8 +503,10 @@ describe("public landing page", () => {
   test("provides a complete agent-readable setup handoff", async () => {
     const setup = await read("setup.md");
 
-    expect(setup).toContain("https://github.com/eabnelson/pronto.git");
-    expect(setup).toContain("bun run packages/cli/src/cli.ts setup");
+    expect(setup).toContain("https://github.com/eabnelson/pronto");
+    expect(setup).toContain('"$PRONTO_CANDIDATE" setup');
+    expect(setup).toContain('identifier \"dev.pronto.cli\"');
+    expect(setup).toContain('certificate leaf[subject.OU] = \"9YCNUWK84C\"');
     expect(setup).toContain("Full Disk Access");
     expect(setup).toContain("doctor");
     expect(setup).toContain("status");
@@ -516,7 +518,7 @@ describe("public landing page", () => {
 
   test("grants setup and installed executables Full Disk Access at the right times", async () => {
     const setup = await read("setup.md");
-    const setupCommand = setup.indexOf("bun run packages/cli/src/cli.ts setup");
+    const setupCommand = setup.indexOf('"$PRONTO_CANDIDATE" setup');
     const setupPermission = setup.indexOf("terminal or parent app that will run setup");
     const installedPermission = setup.indexOf("exact installed executable");
 
@@ -525,27 +527,18 @@ describe("public landing page", () => {
     expect(installedPermission).toBeGreaterThan(setupCommand);
   });
 
-  test("guards an existing checkout before running repository code", async () => {
+  test("downloads and verifies the immutable release identity before setup", async () => {
     const setup = await read("setup.md");
-    const cloneWithChosenPath = setup.indexOf(
-      "git clone https://github.com/eabnelson/pronto.git \"$CHECKOUT\"",
-    );
-    const checkoutUse = setup.indexOf('cd "$CHECKOUT"');
-    const originCheck = setup.indexOf("git remote get-url origin");
-    const exactOrigins = setup.indexOf(
-      "https://github.com/eabnelson/pronto.git|git@github.com:eabnelson/pronto.git)",
-    );
-    const cleanCheck = setup.indexOf("git status --porcelain");
-    const fastForward = setup.indexOf("git pull --ff-only");
-    const install = setup.indexOf("bun install --frozen-lockfile");
+    const download = setup.indexOf("releases/latest/download/pronto-$PRONTO_TARGET");
+    const signature = setup.indexOf("codesign --verify --strict");
+    const version = setup.indexOf('"$PRONTO_CANDIDATE" --version');
+    const install = setup.indexOf('"$PRONTO_CANDIDATE" setup');
 
-    expect(cloneWithChosenPath).toBeGreaterThan(-1);
-    expect(checkoutUse).toBeGreaterThan(-1);
-    expect(originCheck).toBeGreaterThan(-1);
-    expect(exactOrigins).toBeGreaterThan(originCheck);
-    expect(cleanCheck).toBeGreaterThan(originCheck);
-    expect(fastForward).toBeGreaterThan(cleanCheck);
-    expect(install).toBeGreaterThan(fastForward);
+    expect(download).toBeGreaterThan(-1);
+    expect(signature).toBeGreaterThan(download);
+    expect(version).toBeGreaterThan(signature);
+    expect(install).toBeGreaterThan(version);
+    expect(setup).not.toContain("bun run packages/cli/src/cli.ts setup");
   });
 
   test("makes the final installed status check self-contained", async () => {

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -161,7 +161,7 @@ describe("Pronto updater", () => {
       }),
       now: () => new Date("2026-09-05T12:00:00.000Z"),
       randomId: () => "test",
-      restoreAgent: async () => { calls.push("restore"); },
+      installMainAgent: async () => { calls.push("install-main"); },
       run: async (executable, args) => {
         if (args[0] === "--version") return { exitCode: 0, stderr: "", stdout: "pronto 0.3.0\n" };
         calls.push(`${executable}:${args.join(" ")}`);
@@ -183,7 +183,7 @@ describe("Pronto updater", () => {
       createHash("sha256").update(candidate).digest("hex"),
     );
     expect(calls[0]).toBe("stop");
-    expect(calls).toContain("restore");
+    expect(calls).toContain("install-main");
     expect((await stat(paths.executablePath)).mode & 0o777).toBe(0o700);
   });
 
@@ -222,7 +222,7 @@ describe("Pronto updater", () => {
     }));
     const available = manifest(candidate);
     let fetchCount = 0;
-    let restores = 0;
+    let mainAgentInstalls = 0;
     const updater = new ProntoUpdater(paths, {
       currentVersion: "0.2.4",
       fetch: async () => new Response(++fetchCount === 1 ? "manifest" : candidate),
@@ -231,7 +231,7 @@ describe("Pronto updater", () => {
         teamIdentifier: PRONTO_SIGNING_TEAM_IDENTIFIER,
       }),
       randomId: () => "rollback",
-      restoreAgent: async () => { restores += 1; },
+      installMainAgent: async () => { mainAgentInstalls += 1; },
       run: async (_executable, args) => args[0] === "--version"
         ? { exitCode: 0, stderr: "", stdout: "pronto 0.3.0\n" }
         : { exitCode: 1, stderr: "not ready", stdout: "" },
@@ -243,7 +243,7 @@ describe("Pronto updater", () => {
     await expect(updater.install()).rejects.toThrow("update_candidate_qualification_failed");
     expect(await readFile(paths.executablePath, "utf8")).toBe("known good");
     expect((await loadConfig(paths.configPath)).installedExecutableHash).toBe(originalHash);
-    expect(restores).toBe(2);
+    expect(mainAgentInstalls).toBe(2);
   });
 
   test("migrates an existing ad-hoc install from a separately downloaded signed candidate", async () => {
@@ -264,6 +264,7 @@ describe("Pronto updater", () => {
       workingDirectory: home,
     }));
     let updaterInstalled = false;
+    let mainAgentInstalled = false;
     const updater = new ProntoUpdater(paths, {
       currentVersion: "0.3.0",
       inspectIdentity: async (path) => path === paths.executablePath
@@ -273,8 +274,10 @@ describe("Pronto updater", () => {
             teamIdentifier: PRONTO_SIGNING_TEAM_IDENTIFIER,
           },
       installUpdaterAgent: async () => { updaterInstalled = true; },
+      installMainAgent: async (_paths, config) => {
+        mainAgentInstalled = config.primaryRuntimePath === "/usr/local/bin/codex";
+      },
       randomId: () => "migration",
-      restoreAgent: async () => undefined,
       run: async (executable, args) => {
         if (args[0] === "--version") {
           return {
@@ -296,6 +299,7 @@ describe("Pronto updater", () => {
     expect(await readFile(paths.executablePath, "utf8")).toBe("developer-id 0.3.0");
     expect(await readFile(paths.updateBackupPath, "utf8")).toBe("ad-hoc 0.2.4");
     expect(updaterInstalled).toBeTrue();
+    expect(mainAgentInstalled).toBeTrue();
     expect(JSON.parse(await readFile(paths.updateStatePath, "utf8"))).toMatchObject({
       installedVersion: "0.3.0",
     });

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -1,0 +1,303 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  createHash,
+  generateKeyPairSync,
+  sign,
+} from "node:crypto";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  PRONTO_SIGNING_IDENTIFIER,
+  PRONTO_SIGNING_TEAM_IDENTIFIER,
+  PRONTO_UPDATE_KEY_ID,
+  ProntoUpdater,
+  releaseSequenceForVersion,
+  verifyProntoUpdateEnvelope,
+  type ProntoUpdateManifest,
+} from "../../packages/cli/src/update";
+import {
+  createConfig,
+  loadConfig,
+  saveConfig,
+  UNRESTRICTED_TRUST_VERSION,
+} from "../../packages/cli/src/config";
+import { pathsForHome } from "../../packages/cli/src/macos/paths";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((path) => rm(path, { force: true, recursive: true })),
+  );
+});
+
+function manifest(
+  bytes = new TextEncoder().encode("signed candidate"),
+  overrides: Partial<ProntoUpdateManifest> = {},
+): ProntoUpdateManifest {
+  const version = overrides.version ?? "0.3.0";
+  const artifact = {
+    url: `https://github.com/eabnelson/pronto/releases/download/v${version}/pronto-darwin-arm64`,
+    size: bytes.byteLength,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    macosSigning: {
+      identifier: PRONTO_SIGNING_IDENTIFIER,
+      teamIdentifier: PRONTO_SIGNING_TEAM_IDENTIFIER,
+    },
+  };
+  return {
+    schemaVersion: 1,
+    product: "pronto",
+    version,
+    releaseSequence: releaseSequenceForVersion(version),
+    channel: "stable",
+    publishedAt: "2026-09-04T12:00:00.000Z",
+    expiresAt: "2027-09-04T12:00:00.000Z",
+    sourceRevision: "a".repeat(40),
+    minimumUpdaterVersion: "0.2.4",
+    artifacts: {
+      "darwin-arm64": artifact,
+      "darwin-x64": {
+        ...artifact,
+        url: `https://github.com/eabnelson/pronto/releases/download/v${version}/pronto-darwin-x64`,
+      },
+    },
+    ...overrides,
+  };
+}
+
+function signedEnvelope(payload: ProntoUpdateManifest): {
+  bytes: Uint8Array;
+  publicKey: string;
+} {
+  const keys = generateKeyPairSync("ed25519");
+  const payloadBytes = Buffer.from(JSON.stringify(payload));
+  const signature = sign(null, payloadBytes, keys.privateKey);
+  const envelope = {
+    keyId: PRONTO_UPDATE_KEY_ID,
+    payload: payloadBytes.toString("base64url"),
+    signature: signature.toString("base64url"),
+  };
+  return {
+    bytes: new TextEncoder().encode(JSON.stringify(envelope)),
+    publicKey: keys.publicKey.export({ format: "der", type: "spki" }).toString("base64"),
+  };
+}
+
+describe("Pronto update envelope", () => {
+  test("authenticates and validates a bounded release manifest", () => {
+    const signed = signedEnvelope(manifest());
+    expect(verifyProntoUpdateEnvelope(
+      signed.bytes,
+      new Date("2026-09-05T12:00:00.000Z"),
+      signed.publicKey,
+    )).toMatchObject({
+      product: "pronto",
+      releaseSequence: releaseSequenceForVersion("0.3.0"),
+      version: "0.3.0",
+    });
+  });
+
+  test("rejects tampering, expiration, and foreign artifact origins", () => {
+    const signed = signedEnvelope(manifest());
+    const tampered = Uint8Array.from(signed.bytes);
+    tampered[tampered.length - 2] = tampered[tampered.length - 2]! ^ 1;
+    expect(() => verifyProntoUpdateEnvelope(
+      tampered,
+      new Date("2026-09-05T12:00:00.000Z"),
+      signed.publicKey,
+    )).toThrow();
+    expect(() => verifyProntoUpdateEnvelope(
+      signed.bytes,
+      new Date("2028-09-05T12:00:00.000Z"),
+      signed.publicKey,
+    )).toThrow("update_manifest_expired");
+
+    const foreign = manifest();
+    foreign.artifacts["darwin-arm64"] = {
+      ...foreign.artifacts["darwin-arm64"],
+      url: "https://example.com/pronto",
+    };
+    const foreignSigned = signedEnvelope(foreign);
+    expect(() => verifyProntoUpdateEnvelope(
+      foreignSigned.bytes,
+      new Date("2026-09-05T12:00:00.000Z"),
+      foreignSigned.publicKey,
+    )).toThrow("update_artifact_origin_invalid");
+  });
+});
+
+describe("Pronto updater", () => {
+  test("stages, verifies, atomically installs, and records a qualified update", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pronto-update-"));
+    temporaryDirectories.push(home);
+    const paths = pathsForHome(home);
+    const candidate = new TextEncoder().encode("signed candidate");
+    await mkdir(join(paths.appSupportDirectory, "bin"), { recursive: true });
+    await writeFile(paths.executablePath, "previous", { mode: 0o700 });
+    await chmod(paths.executablePath, 0o700);
+    await saveConfig(paths.configPath, createConfig({
+      imsgPath: "/usr/local/bin/imsg",
+      installedExecutableHash: createHash("sha256").update("previous").digest("hex"),
+      primaryRuntime: "codex",
+      primaryRuntimePath: "/usr/local/bin/codex",
+      tags: ["@pronto"],
+      unrestrictedTrustVersion: UNRESTRICTED_TRUST_VERSION,
+      workingDirectory: home,
+    }));
+    const available = manifest(candidate);
+    const calls: string[] = [];
+    let fetchCount = 0;
+    const updater = new ProntoUpdater(paths, {
+      currentVersion: "0.2.4",
+      fetch: async () => {
+        fetchCount += 1;
+        return new Response(fetchCount === 1 ? "manifest" : candidate);
+      },
+      inspectIdentity: async () => ({
+        identifier: PRONTO_SIGNING_IDENTIFIER,
+        teamIdentifier: PRONTO_SIGNING_TEAM_IDENTIFIER,
+      }),
+      now: () => new Date("2026-09-05T12:00:00.000Z"),
+      randomId: () => "test",
+      restoreAgent: async () => { calls.push("restore"); },
+      run: async (executable, args) => {
+        if (args[0] === "--version") return { exitCode: 0, stderr: "", stdout: "pronto 0.3.0\n" };
+        calls.push(`${executable}:${args.join(" ")}`);
+        return { exitCode: 0, stderr: "", stdout: "{}" };
+      },
+      stopAgent: async () => { calls.push("stop"); },
+      verifyEnvelope: () => available,
+      wait: async () => undefined,
+    });
+
+    expect(await updater.install()).toEqual({ status: "installed", version: "0.3.0" });
+    expect(await readFile(paths.executablePath, "utf8")).toBe("signed candidate");
+    expect(await readFile(paths.updateBackupPath, "utf8")).toBe("previous");
+    expect(JSON.parse(await readFile(paths.updateStatePath, "utf8"))).toMatchObject({
+      highestReleaseSequence: releaseSequenceForVersion("0.3.0"),
+      installedVersion: "0.3.0",
+    });
+    expect((await loadConfig(paths.configPath)).installedExecutableHash).toBe(
+      createHash("sha256").update(candidate).digest("hex"),
+    );
+    expect(calls[0]).toBe("stop");
+    expect(calls).toContain("restore");
+    expect((await stat(paths.executablePath)).mode & 0o777).toBe(0o700);
+  });
+
+  test("requires an explicit one-time migration from an ad-hoc install", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pronto-update-migration-"));
+    temporaryDirectories.push(home);
+    const paths = pathsForHome(home);
+    const updater = new ProntoUpdater(paths, {
+      currentVersion: "0.2.4",
+      fetch: async () => new Response("manifest"),
+      inspectIdentity: async () => undefined,
+      verifyEnvelope: () => manifest(),
+    });
+    expect(await updater.install()).toEqual({
+      status: "migration_required",
+      version: "0.3.0",
+    });
+  });
+
+  test("rolls back the executable and configuration when the candidate never becomes ready", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pronto-update-rollback-"));
+    temporaryDirectories.push(home);
+    const paths = pathsForHome(home);
+    const candidate = new TextEncoder().encode("broken candidate");
+    await mkdir(join(paths.appSupportDirectory, "bin"), { recursive: true });
+    await writeFile(paths.executablePath, "known good", { mode: 0o700 });
+    const originalHash = createHash("sha256").update("known good").digest("hex");
+    await saveConfig(paths.configPath, createConfig({
+      imsgPath: "/usr/local/bin/imsg",
+      installedExecutableHash: originalHash,
+      primaryRuntime: "codex",
+      primaryRuntimePath: "/usr/local/bin/codex",
+      tags: ["@pronto"],
+      unrestrictedTrustVersion: UNRESTRICTED_TRUST_VERSION,
+      workingDirectory: home,
+    }));
+    const available = manifest(candidate);
+    let fetchCount = 0;
+    let restores = 0;
+    const updater = new ProntoUpdater(paths, {
+      currentVersion: "0.2.4",
+      fetch: async () => new Response(++fetchCount === 1 ? "manifest" : candidate),
+      inspectIdentity: async () => ({
+        identifier: PRONTO_SIGNING_IDENTIFIER,
+        teamIdentifier: PRONTO_SIGNING_TEAM_IDENTIFIER,
+      }),
+      randomId: () => "rollback",
+      restoreAgent: async () => { restores += 1; },
+      run: async (_executable, args) => args[0] === "--version"
+        ? { exitCode: 0, stderr: "", stdout: "pronto 0.3.0\n" }
+        : { exitCode: 1, stderr: "not ready", stdout: "" },
+      stopAgent: async () => undefined,
+      verifyEnvelope: () => available,
+      wait: async () => undefined,
+    });
+
+    await expect(updater.install()).rejects.toThrow("update_candidate_qualification_failed");
+    expect(await readFile(paths.executablePath, "utf8")).toBe("known good");
+    expect((await loadConfig(paths.configPath)).installedExecutableHash).toBe(originalHash);
+    expect(restores).toBe(2);
+  });
+
+  test("migrates an existing ad-hoc install from a separately downloaded signed candidate", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pronto-update-local-migration-"));
+    temporaryDirectories.push(home);
+    const paths = pathsForHome(home);
+    const candidatePath = join(home, "downloaded-pronto");
+    await mkdir(join(paths.appSupportDirectory, "bin"), { recursive: true });
+    await writeFile(paths.executablePath, "ad-hoc 0.2.4", { mode: 0o700 });
+    await writeFile(candidatePath, "developer-id 0.3.0", { mode: 0o700 });
+    await saveConfig(paths.configPath, createConfig({
+      imsgPath: "/usr/local/bin/imsg",
+      installedExecutableHash: createHash("sha256").update("ad-hoc 0.2.4").digest("hex"),
+      primaryRuntime: "codex",
+      primaryRuntimePath: "/usr/local/bin/codex",
+      tags: ["@pronto"],
+      unrestrictedTrustVersion: UNRESTRICTED_TRUST_VERSION,
+      workingDirectory: home,
+    }));
+    let updaterInstalled = false;
+    const updater = new ProntoUpdater(paths, {
+      currentVersion: "0.3.0",
+      inspectIdentity: async (path) => path === paths.executablePath
+        ? undefined
+        : {
+            identifier: PRONTO_SIGNING_IDENTIFIER,
+            teamIdentifier: PRONTO_SIGNING_TEAM_IDENTIFIER,
+          },
+      installUpdaterAgent: async () => { updaterInstalled = true; },
+      randomId: () => "migration",
+      restoreAgent: async () => undefined,
+      run: async (executable, args) => {
+        if (args[0] === "--version") {
+          return {
+            exitCode: 0,
+            stderr: "",
+            stdout: executable === paths.executablePath ? "pronto 0.2.4\n" : "pronto 0.3.0\n",
+          };
+        }
+        return { exitCode: 1, stderr: "full disk access required", stdout: "" };
+      },
+      stopAgent: async () => undefined,
+      wait: async () => undefined,
+    });
+
+    expect(await updater.migrateLocalCandidate(candidatePath)).toEqual({
+      status: "migration_installed",
+      version: "0.3.0",
+    });
+    expect(await readFile(paths.executablePath, "utf8")).toBe("developer-id 0.3.0");
+    expect(await readFile(paths.updateBackupPath, "utf8")).toBe("ad-hoc 0.2.4");
+    expect(updaterInstalled).toBeTrue();
+    expect(JSON.parse(await readFile(paths.updateStatePath, "utf8"))).toMatchObject({
+      installedVersion: "0.3.0",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- ship architecture-specific Developer ID signed and notarized Pronto binaries
- verify an Ed25519-signed stable update manifest, exact hashes, versions, origins, and Apple identity
- install updates every six hours with locking, health qualification, and last-known-good rollback
- provide a one-time ad-hoc-to-permanent-signing migration and document the release trust model
- publish `pronto-imessage` 0.3.0 with npm provenance and GitHub artifact attestations

## Verification
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun test` (246 passing)
- `bun run build` / `./dist/pronto --version`
- `bun run release:validate`
- `actionlint .github/workflows/release.yml`
- secret scan and `git diff --check`

## Release gate
Do not merge/tag until the protected `release` environment has the Developer ID and notarization secrets and the pending signed v0.3.0 live qualification rows in `docs/RELEASE_QUALIFICATION.md` are complete.