### PR TITLE
fix: validate codesign runtime flags correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
             signing_info="$(codesign -dv --verbose=4 "release/$asset" 2>&1)"
             test "$(sed -n 's/^Identifier=//p' <<< "$signing_info")" = "$PRONTO_SIGNING_IDENTIFIER"
             test "$(sed -n 's/^TeamIdentifier=//p' <<< "$signing_info")" = "$PRONTO_SIGNING_TEAM_IDENTIFIER"
-            grep -q '^flags=.*runtime' <<< "$signing_info"
+            grep -Eq '^CodeDirectory .*flags=.*runtime' <<< "$signing_info"
             grep -q '^Timestamp=' <<< "$signing_info"
             archive="$RUNNER_TEMP/$asset.zip"
             ditto -c -k --keepParent "release/$asset" "$archive"

--- a/scripts/release-workflow-validation.ts
+++ b/scripts/release-workflow-validation.ts
@@ -11,6 +11,7 @@ const REQUIRED_CONTROLS = [
   ["sha256sum -c pronto-imessage.sha256", "downloaded package checksum verification"],
   ["environment: release", "protected release environment"],
   ["codesign --force --options runtime --timestamp", "Developer ID hardened-runtime signing"],
+  ["grep -Eq '^CodeDirectory .*flags=.*runtime'", "hardened-runtime signature assertion"],
   ["xcrun notarytool submit", "Apple notarization"],
   ["PRONTO_RELEASE_ED25519_PRIVATE_KEY", "signed update manifest credential"],
   ["bun scripts/generate-update-manifest.ts", "signed update manifest generation"],

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -24,6 +24,7 @@ describe("release workflow", () => {
     expect(beforePublish).toContain('$package');
     expect(workflow).toContain("codesign --verify --strict --verbose=4 -R=\"$requirement\"");
     expect(workflow).toContain("codesign --force --options runtime --timestamp");
+    expect(workflow).toContain("grep -Eq '^CodeDirectory .*flags=.*runtime'");
     expect(workflow).toContain("xcrun notarytool submit");
     expect(workflow).toContain("environment: release");
     expect(workflow).toContain("pronto-update.json");


### PR DESCRIPTION
The v0.3.0 release runner signed and verified the artifact correctly, then rejected it because codesign reports hardened-runtime flags on the `CodeDirectory` line rather than a line beginning with `flags=`. This updates the assertion and makes it a required workflow control.\n\nValidation: `bun test test/unit/release-workflow.test.ts`; release workflow validation; actionlint.