### PR TITLE
Harden message recovery and add signed candidate qualification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,14 @@ on:
   push:
     tags:
       - "v*"
+      - "!v*-candidate.*"
   workflow_dispatch:
+    inputs:
+      candidate_only:
+        description: "Build signed smoke-test artifacts only; never publish"
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -16,6 +23,7 @@ jobs:
     environment: release
     env:
       RELEASE_TAG: ${{ github.ref_name }}
+      CANDIDATE_ONLY: ${{ inputs.candidate_only == true }}
       PRONTO_SIGNING_IDENTIFIER: dev.pronto.cli
       PRONTO_SIGNING_TEAM_IDENTIFIER: 9YCNUWK84C
     permissions:
@@ -51,7 +59,13 @@ jobs:
           VERSION="$(bun -e 'import packageJson from "./package.json" with { type: "json" }; process.stdout.write(packageJson.version)')"
           PACKAGE_VERSION="$(bun -e 'import packageJson from "./packages/messages/package.json" with { type: "json" }; process.stdout.write(packageJson.version)')"
           test "$GITHUB_REF_TYPE" = "tag"
-          test "v$VERSION" = "$RELEASE_TAG"
+          if [[ "$CANDIDATE_ONLY" = "true" ]]; then
+            candidate_prefix="v$VERSION-candidate."
+            test "${RELEASE_TAG:0:${#candidate_prefix}}" = "$candidate_prefix"
+            [[ "${RELEASE_TAG#"$candidate_prefix"}" =~ ^[1-9][0-9]*$ ]]
+          else
+            test "v$VERSION" = "$RELEASE_TAG"
+          fi
           test "$VERSION" = "$PACKAGE_VERSION"
           test "$(git rev-parse HEAD)" = "$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")"
           {
@@ -65,6 +79,7 @@ jobs:
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Verify owner qualification is complete
+        if: ${{ inputs.candidate_only != true }}
         run: bun ./scripts/release-qualification.ts docs/RELEASE_QUALIFICATION.md "$RELEASE_TAG"
       - name: Build native release artifacts
         env:
@@ -144,6 +159,7 @@ jobs:
           test "$(arch -arm64 ./release/pronto-darwin-arm64 --version)" = "pronto $PRONTO_RELEASE_VERSION"
           test "$(arch -x86_64 ./release/pronto-darwin-x64 --version)" = "pronto $PRONTO_RELEASE_VERSION"
       - name: Create signed update manifest and checksums
+        if: ${{ inputs.candidate_only != true }}
         env:
           PRONTO_RELEASE_DIRECTORY: release
           PRONTO_RELEASE_VERSION: ${{ steps.release-version.outputs.package-version }}
@@ -159,6 +175,18 @@ jobs:
           shasum -a 256 -c pronto.sha256
           shasum -a 256 "${{ steps.release-version.outputs.package-file }}" > pronto-imessage.sha256
           shasum -a 256 -c pronto-imessage.sha256
+      - name: Build candidate checksums
+        if: ${{ inputs.candidate_only == true }}
+        env:
+          PRONTO_CANDIDATE_VERSION: ${{ steps.release-version.outputs.package-version }}
+        run: |
+          npm pack ./packages/messages --pack-destination ./release
+          bun -e 'console.log(JSON.stringify({version: process.env.PRONTO_CANDIDATE_VERSION, sourceRevision: process.env.GITHUB_SHA, runId: process.env.GITHUB_RUN_ID, tag: process.env.RELEASE_TAG}))' > release/pronto-candidate.json
+          cd release
+          shasum -a 256 pronto-darwin-arm64 pronto-darwin-x64 pronto-candidate.json > pronto.sha256
+          shasum -a 256 -c pronto.sha256
+          shasum -a 256 "${{ steps.release-version.outputs.package-file }}" > pronto-imessage.sha256
+          shasum -a 256 -c pronto-imessage.sha256
       - name: Remove temporary signing material
         if: always()
         run: |
@@ -169,17 +197,19 @@ jobs:
             -delete
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: pronto-release
-          retention-days: 1
+          name: ${{ inputs.candidate_only && 'pronto-candidate' || 'pronto-release' }}
+          retention-days: 7
           path: |
             release/pronto-darwin-arm64
             release/pronto-darwin-x64
             release/pronto-update.json
+            release/pronto-candidate.json
             release/pronto.sha256
             release/pronto-imessage-*.tgz
             release/pronto-imessage.sha256
 
   publish:
+    if: ${{ inputs.candidate_only != true && !contains(github.ref_name, '-candidate.') }}
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
     },
     "packages/cli": {
       "name": "pronto-cli",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "bin": {
         "pronto": "./src/cli.ts",
         "s4imsg": "./src/legacy-cli.ts",
@@ -24,7 +24,7 @@
     },
     "packages/messages": {
       "name": "pronto-imessage",
-      "version": "0.3.0",
+      "version": "0.4.0",
     },
   },
   "packages": {

--- a/docs/RELEASE_QUALIFICATION.md
+++ b/docs/RELEASE_QUALIFICATION.md
@@ -3,6 +3,12 @@
 Public release requires every automated gate and an owner-run live smoke. This
 file records capability evidence, not private conversation data.
 
+The matrix below is historical v0.3.0 evidence. The v0.4.0 candidate has not yet
+passed fresh owner smoke or signed-to-signed replacement qualification. Its
+candidate-only CI build may run; public v0.4.0 release remains blocked until this
+matrix is updated with actual evidence. Never carry the v0.3.0 remote smoke
+forward across the v0.4.0 message-transport changes.
+
 ## Current matrix
 
 | Surface | Qualified version | Evidence | Status |

--- a/docs/UPDATES.md
+++ b/docs/UPDATES.md
@@ -86,6 +86,24 @@ immutable GitHub release public.
 
 ## Release qualification
 
+When the signing identity is available only in CI, first freeze the runtime and
+package version on an immutable `v<version>-candidate.<number>` tag. Dispatch
+`release.yml` on that tag with `candidate_only=true`. Candidate tags do not
+trigger automatic release builds; the manual build still requires the protected
+`release` environment and runs the same tests, signature and notarization checks.
+It uploads a `pronto-candidate` Actions artifact with checksums and source/run
+metadata, but creates no update manifest, npm publication or GitHub release.
+
+Download the artifact from that exact successful run, verify both checksum files
+and the Developer ID designated requirement before executing it. Keep a private
+copy of the installed binary/configuration and use the existing quiesce and
+identity-preserving installation lifecycle. Never install an ad-hoc substitute to
+complete the live gate. Record the candidate source revision, binary checksum,
+version and fresh owner smoke in the qualification evidence. Freeze runtime code
+through qualification; a runtime change requires a new candidate and fresh smoke.
+Only qualification/documentation changes may separate the candidate source from
+the final same-version release tag, and that diff must be reviewed explicitly.
+
 Before tagging a release, install the exact signed candidate over the prior
 signed production release on every supported macOS version. Confirm that Full
 Disk Access remains effective from the launchd-started listener, one explicit

--- a/docs/adr/0005-position-history-within-observed-conversations.md
+++ b/docs/adr/0005-position-history-within-observed-conversations.md
@@ -1,0 +1,11 @@
+---
+status: proposed
+---
+
+# Position history within an observed conversation
+
+Add an optional `afterRowId` to bounded forward history, usable only with a current conversation reference and without a continuation. A durable consumer can re-observe its exact account and conversation, then read one known row without scanning unrelated history; existing reference, generation, expiry and cumulative-budget checks still apply.
+
+The consumer must retain and compare the original generation, account, conversation, row, message identity and content digest before execution, then obtain current product authority. A row position is a search bound, not an authorization capability or proof that a message is unchanged. Consumers negotiate `positioned-history` in module qualification before depending on it, since older modules would ignore an unknown option.
+
+The restart experiment is preserved on `erik/prototype/message-replay` at `3faa60c`. It restored the unchanged synthetic message and distinguished edited/deleted/replaced messages, account changes and database replacement without persisting message bodies. Queue expiry was modeled, not a real-time durability test; production tests must verify it. This keeps raw RPC internal and avoids a second kind of sealed message capability.

--- a/docs/analysis/2026-09-04-reliability-review.md
+++ b/docs/analysis/2026-09-04-reliability-review.md
@@ -1,0 +1,17 @@
+# Reliability candidate review
+
+Baseline: `700155e6ce03ad6d51dc498724f4bb6608e209f0`. The remote main update to `04f92a9` was a merge-only commit with no tree difference. Reviewed work: arrival/buffer recovery, reconnect deadlines/backoff, positioned scoped history and candidate-only signing. Standards and Spec reviewed sequentially under the workspace's subagent mapping.
+
+## Standards
+
+The public module remains independent of downstream product code; raw RPC stays internal. The optional position does not create an unscoped capability or replace generation, expiry, routing or cumulative-budget checks. Arrival handling keeps a fixed 256-entry notification buffer and one drain task. Request close-wait listeners are removed after completion; closed subscriptions discard pending memory. These review cleanups resolved resource-lifetime concerns without introducing another queue framework.
+
+Candidate signing reuses the existing protected build job rather than duplicating signing logic. Candidate tags are excluded from automatic release triggers. Manual candidate input fences the entire publish job and update-manifest generation; ordinary releases retain the owner qualification gate and immutable version/tag checks. No credential, Apple identity or npm trust policy was changed. YAML and shell syntax were checked; removal-of-guard regressions pass. No blocking Standards findings remain for the candidate.
+
+## Spec
+
+Regressions cover delayed live callbacks, bounded 10,000-notification recovery, historical age limits, stable versus flapping backoff, reconnect deadline exhaustion without late send submission, synchronous connection-factory failure, and scoped history positions. Existing standalone duplicate, uncertain-effect, shutdown, updater, signature, rollback and Node/Bun compatibility suites remain green. The replay prototype is preserved at `3faa60c` and the proposed ADR records its limitations.
+
+The exact candidate has not completed owner live smoke or signed-to-signed replacement. Historical v0.3.0 evidence cannot qualify changed v0.4.0 transport. Candidate artifacts are for qualification only; the public release gate deliberately still fails for v0.4.0. No real message was sent during local verification. Downstream durable-worker crash-boundary qualification and exact published-version adoption remain separate work, not established by these provider tests.
+
+Summary: Standards 0 unresolved blocking findings; Spec 1 release-blocking qualification gap (fresh signed-candidate owner smoke). Local typecheck/build, 256 tests and offline release validation passed before candidate publication; the protected CI run must independently repeat them.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-workspace",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A local iMessage bridge for Codex and Claude Code",
   "type": "module",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pronto-imessage",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Reusable local Apple Messages transport for Pronto consumers",
   "type": "module",
   "license": "MIT",

--- a/packages/messages/src/index.ts
+++ b/packages/messages/src/index.ts
@@ -69,6 +69,7 @@ export type {
 } from "./types.js";
 
 const CHAT_CATALOG_LIMITS = [128, 512, 2_048, 4_096] as const;
+const MAX_PENDING_NOTIFICATIONS = 256;
 
 function safeProviderCoordinate(value: unknown): value is string {
   return typeof value === "string" && value.length > 0 && value.length <= 1_024 &&
@@ -179,6 +180,7 @@ class ProntoMessagesClient implements ProntoMessages {
     this.#databasePath = path;
     return {
       ...qualify(snapshot),
+      moduleCapabilities: ["positioned-history"],
       databaseGeneration: await databaseGeneration(path),
     };
   }
@@ -279,7 +281,39 @@ class ProntoMessagesClient implements ProntoMessages {
         this.#diagnostics = { ...this.#diagnostics, state: "degraded" };
       });
     };
-    const pendingNotifications: RpcNotification[] = [];
+    const pendingNotifications: { notification: RpcNotification; arrivedAt: number }[] = [];
+    let notificationDrainScheduled = false;
+    let notificationOverflowed = false;
+    const flushNotifications = (): void => {
+      if (notificationDrainScheduled || subscriptionId === null || closed ||
+        (pendingNotifications.length === 0 && !notificationOverflowed)) return;
+      notificationDrainScheduled = true;
+      enqueue(async () => {
+        try {
+          while (!closed && subscriptionId !== null && pendingNotifications.length > 0) {
+            const next = pendingNotifications.shift()!;
+            this.#diagnostics = { ...this.#diagnostics, pendingNotifications: pendingNotifications.length };
+            await handleNotification(next.notification, next.arrivedAt);
+          }
+          if (notificationOverflowed && !closed) {
+            await detachProvider();
+            const checkpoint = await this.#state.checkpoint(databaseGeneration);
+            notificationOverflowed = false;
+            if (checkpoint !== undefined) {
+              await Promise.resolve(input.onOverflow?.(checkpoint.rowId)).catch(() => undefined);
+              await recoverUntilSubscribed();
+            } else {
+              await report({ status: "degraded", action: "live-events-only",
+                reason: "notification-buffer-limit", rows: 0 });
+              await subscribeProvider(false);
+            }
+          }
+        } finally {
+          notificationDrainScheduled = false;
+          flushNotifications();
+        }
+      });
+    };
     const detachProvider = async (): Promise<void> => {
       const active = subscriptionId;
       subscriptionId = null;
@@ -329,9 +363,7 @@ class ProntoMessagesClient implements ProntoMessages {
         return;
       }
       subscriptionId = result.subscription;
-      for (const notification of pendingNotifications.splice(0)) {
-        enqueue(async () => await handleNotification(notification));
-      }
+      flushNotifications();
     };
     const recover = async (boundaryReason?: MessagesRecoveryReason): Promise<void> => {
       if (closed) return;
@@ -482,7 +514,7 @@ class ProntoMessagesClient implements ProntoMessages {
       };
       enqueue(settle);
     };
-    const handleNotification = async (notification: RpcNotification): Promise<void> => {
+    const handleNotification = async (notification: RpcNotification, arrivedAt: number): Promise<void> => {
       if (closed) return;
       const params = record(notification.params);
       if (params.subscription !== subscriptionId) return;
@@ -518,7 +550,7 @@ class ProntoMessagesClient implements ProntoMessages {
         return;
       }
       const occurredAtMs = rawMessageDateMs(rawMessage);
-      if (occurredAtMs === null || Date.now() - occurredAtMs > this.#limits.maxLiveAgeMs) {
+      if (occurredAtMs === null || arrivedAt - occurredAtMs > this.#limits.maxLiveAgeMs) {
         await this.#advancePastSuppressed(rawMessage, databaseGeneration);
         return;
       }
@@ -536,11 +568,16 @@ class ProntoMessagesClient implements ProntoMessages {
       }
     };
     const dispose = this.#rpc.onNotification((notification) => {
-      if (subscriptionId === null) {
-        pendingNotifications.push(notification);
+      if (closed || notificationOverflowed) return;
+      if (pendingNotifications.length >= MAX_PENDING_NOTIFICATIONS) {
+        notificationOverflowed = true;
+        flushNotifications();
         return;
       }
-      enqueue(async () => await handleNotification(notification));
+      const arrivedAt = Date.now();
+      pendingNotifications.push({ notification, arrivedAt });
+      this.#diagnostics = { ...this.#diagnostics, pendingNotifications: pendingNotifications.length };
+      flushNotifications();
     });
     const disposeRestart = this.#rpc.onRestart(() => {
       if (closed) return;
@@ -553,6 +590,8 @@ class ProntoMessagesClient implements ProntoMessages {
         close: async () => {
           if (closed) return;
           closed = true;
+          pendingNotifications.length = 0;
+          this.#diagnostics = { ...this.#diagnostics, pendingNotifications: 0 };
           signalClosed();
           dispose();
           disposeRestart();

--- a/packages/messages/src/internal/rpc.ts
+++ b/packages/messages/src/internal/rpc.ts
@@ -236,6 +236,7 @@ export class ResilientRpcClient {
   readonly #random: () => number;
   readonly #notifications = new Set<(notification: RpcNotification) => void>();
   readonly #restartHandlers = new Set<() => void>();
+  readonly #closeWaiters = new Set<() => void>();
   #connection: RpcConnection;
   #disposeConnection: (() => void)[] = [];
   #restart: Promise<void> | undefined;
@@ -244,6 +245,7 @@ export class ResilientRpcClient {
   #resolveTerminated!: () => void;
   #diagnostics: RpcDiagnostics = { attempt: 0, restartCount: 0, state: "ready" };
   #backoffMs = 1_000;
+  #healthySince: number;
 
   constructor(input: {
     readonly connect: () => RpcConnection;
@@ -253,6 +255,7 @@ export class ResilientRpcClient {
   }) {
     this.#connect = input.connect;
     this.#now = input.now ?? Date.now;
+    this.#healthySince = this.#now();
     this.#random = input.random ?? Math.random;
     this.#wait = input.wait ?? (async (milliseconds) => {
       await new Promise<void>((resolve) => {
@@ -290,16 +293,42 @@ export class ResilientRpcClient {
     params: Readonly<Record<string, unknown>> = {},
     timeoutMs = 30_000,
   ): Promise<unknown> {
-    await this.#restart;
+    const deadline = this.#now() + timeoutMs;
+    if (this.#restart !== undefined) {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      let closed: (() => void) | undefined;
+      try {
+        await Promise.race([
+          this.#restart,
+          new Promise<never>((_resolve, reject) => {
+            closed = () => reject(new Error("imsg RPC client is closed"));
+            this.#closeWaiters.add(closed);
+            if (this.#closed) closed();
+          }),
+          new Promise<never>((_resolve, reject) => {
+            timer = setTimeout(() => reject(
+              new Error(`imsg RPC request timed out before submission: ${method}`),
+            ), timeoutMs);
+          }),
+        ]);
+      } finally {
+        if (timer !== undefined) clearTimeout(timer);
+        if (closed !== undefined) this.#closeWaiters.delete(closed);
+      }
+    }
     if (this.#closed) throw new Error("imsg RPC client is closed");
+    const remaining = deadline - this.#now();
+    if (remaining <= 0) throw new Error(`imsg RPC request timed out before submission: ${method}`);
     // A request submitted to a failed process rejects from that process. It is
     // deliberately never replayed here, especially when the method is `send`.
-    return await this.#connection.request(method, params, timeoutMs);
+    return await this.#connection.request(method, params, remaining);
   }
 
   async close(): Promise<void> {
     if (this.#closed) return;
     this.#closed = true;
+    for (const closed of this.#closeWaiters) closed();
+    this.#closeWaiters.clear();
     for (const dispose of this.#disposeConnection.splice(0)) dispose();
     await this.#connection.close().catch(() => undefined);
     this.#resolveTerminated();
@@ -316,6 +345,7 @@ export class ResilientRpcClient {
 
   #beginRestart(failed: RpcConnection): void {
     if (this.#closed || failed !== this.#connection || this.#restart !== undefined) return;
+    if (this.#now() - this.#healthySince >= 30_000) this.#backoffMs = 1_000;
     this.#restart = this.#restartLoop(failed).finally(() => {
       this.#restart = undefined;
     });
@@ -338,14 +368,16 @@ export class ResilientRpcClient {
       };
       await this.#wait(delayMs);
       if (this.#closed) return;
-      const next = this.#connect();
+      let next: RpcConnection | undefined;
       try {
+        next = this.#connect();
         await next.request("initialize", { protocol_version: 1 }, 10_000);
         if (this.#closed) {
           await next.close().catch(() => undefined);
           return;
         }
         this.#connection = next;
+        this.#healthySince = this.#now();
         this.#bind(next);
         this.#restartCount += 1;
         this.#backoffMs = Math.min(60_000, this.#backoffMs * 2);
@@ -357,7 +389,7 @@ export class ResilientRpcClient {
         for (const handler of this.#restartHandlers) handler();
         return;
       } catch {
-        await next.close().catch(() => undefined);
+        await next?.close().catch(() => undefined);
         this.#backoffMs = Math.min(60_000, this.#backoffMs * 2);
         attempt += 1;
       }

--- a/packages/messages/src/internal/scoped.ts
+++ b/packages/messages/src/internal/scoped.ts
@@ -397,6 +397,7 @@ export class ScopedMessagesAccess {
   }
 
   async history(input: {
+    readonly afterRowId?: number;
     readonly budget: MessagesHistoryBudget;
     readonly continuation?: string;
     readonly conversation: ConversationReference;
@@ -404,6 +405,10 @@ export class ScopedMessagesAccess {
     readonly mode?: "forward" | "recent";
   }): Promise<MessagesHistoryPage> {
     if (!validBudget(input.budget)) throw new Error("messages_history_budget_invalid");
+    if (input.afterRowId !== undefined && (!nonNegativeInteger(input.afterRowId) ||
+      input.mode !== "forward" || input.continuation !== undefined)) {
+      throw new Error("messages_history_position_invalid");
+    }
     const scope = await this.conversation(input.conversation);
     const usage = this.#capabilityUsage(scope);
     const continuation = input.continuation === undefined
@@ -437,7 +442,7 @@ export class ScopedMessagesAccess {
     usage.historyMessages += remaining.maxMessages;
     usage.historyRows += remaining.maxRows;
     usage.historyRpcCalls += 1;
-    const cursor = continuation?.cursor ?? 0;
+    const cursor = continuation?.cursor ?? input.afterRowId ?? 0;
     const method = continuation === undefined && mode === "recent"
       ? "messages.history"
       : "messages.after";

--- a/packages/messages/src/types.ts
+++ b/packages/messages/src/types.ts
@@ -75,6 +75,7 @@ export type DeliveryOutcome =
   | { readonly retryable: boolean; readonly status: "failed" };
 
 export interface MessagesQualification {
+  readonly moduleCapabilities?: readonly string[];
   readonly databaseGeneration: string;
   readonly degradedCapabilities: readonly string[];
   readonly providerVersion: string;
@@ -102,6 +103,7 @@ export type MessagesRecoveryReason =
   | "duration-limit"
   | "invalid-provider-page"
   | "provider-unavailable"
+  | "notification-buffer-limit"
   | "row-limit";
 
 export type MessagesRecoveryOutcome =
@@ -117,6 +119,7 @@ export type MessagesRecoveryOutcome =
   };
 
 export interface MessagesDiagnostics {
+  readonly pendingNotifications?: number;
   readonly attempt: number;
   readonly catchUpRows: number;
   readonly databaseGenerationDigest?: string;
@@ -188,6 +191,8 @@ export interface ProntoMessages {
   close(): Promise<void>;
   diagnostics(): MessagesDiagnostics;
   history(input: {
+    /** Start a forward scan after this row, within the observed conversation. */
+    readonly afterRowId?: number;
     readonly budget: MessagesHistoryBudget;
     readonly continuation?: string;
     readonly conversation: ConversationReference;

--- a/packages/messages/test/recovery.test.ts
+++ b/packages/messages/test/recovery.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, test } from "bun:test";
+import { afterEach, expect, spyOn, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { chmod, mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -52,6 +52,111 @@ function checkpointWitness(rowId = 40, providerMessageId = "checkpoint-guid") {
     rowId,
   };
 }
+
+test("keeps both fresh live messages when the first consumer takes six minutes", async () => {
+  const directory = await fixtureDirectory();
+  const databasePath = join(directory, "chat.db");
+  await writeFile(databasePath, "database evidence");
+  const executable = await executableWithSource(directory, rpcLoop(`
+    let result = { ok: true };
+    if (request.method === "initialize") result = {
+      protocol_version: 1, version: "0.15.0",
+      database: { path: ${JSON.stringify(databasePath)}, ready: true, features: { routing_metadata: true } },
+      methods: ["initialize", "status", "chats.list", "messages.history", "messages.after", "messages.stats", "watch.subscribe", "watch.unsubscribe", "send"],
+    };
+    if (request.method === "messages.stats") result = {
+      chats: [{ chat_id: request.params.chat_id, service: "iMessage" }], sent_messages: 1,
+    };
+    if (request.method === "watch.subscribe") result = { subscription: 1 };
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: request.id, result }) + "\\n");
+    if (request.method === "watch.subscribe") {
+      const created_at = new Date().toISOString();
+      process.stdout.write([1, 2].map((id) => JSON.stringify({
+        jsonrpc: "2.0", method: "message", params: { subscription: 1,
+          message: { chat_id: 40 + id, created_at, guid: "live-" + id, id,
+            is_from_me: true, service: "iMessage", text: "hello" },
+        },
+      }) + "\\n").join(""));
+    }
+  `));
+  const messages = createProntoMessages({ imsgPath: executable });
+  const delivered: number[] = [];
+  const realNow = Date.now;
+  let offset = 0;
+  const clock = spyOn(Date, "now").mockImplementation(() => realNow() + offset);
+  let subscription: Awaited<ReturnType<typeof messages.subscribe>> | undefined;
+  try {
+    subscription = await messages.subscribe({
+    onEvent: (event) => {
+      delivered.push(event.message.rowId);
+      if (event.message.rowId === 1) offset = 6 * 60_000;
+    },
+  });
+    const deadline = realNow() + 1_000;
+    while (delivered.length < 2 && realNow() < deadline) await Bun.sleep(10);
+    expect(delivered).toEqual([1, 2]);
+  } finally {
+    clock.mockRestore();
+    await subscription?.close();
+    await messages.close();
+  }
+});
+
+test.each([300, 10_000])("bounds notification memory and recovers a %i-message burst", async (count) => {
+  const directory = await fixtureDirectory();
+  const databasePath = join(directory, "chat.db");
+  await writeFile(databasePath, "database evidence");
+  const executable = await executableWithSource(directory, `
+    let subscriptions = 0;
+    const created_at = new Date().toISOString();
+    const count = ${count};
+    const messages = Array.from({ length: count }, (_, index) => ({
+      id: index + 1, chat_id: 42, guid: "burst-" + (index + 1), created_at,
+      is_from_me: true, service: "iMessage", text: "hello",
+    }));
+    ${rpcLoop(`
+      let result = { ok: true };
+      if (request.method === "initialize") result = {
+        protocol_version: 1, version: "0.15.0",
+        database: { path: ${JSON.stringify(databasePath)}, ready: true, features: { routing_metadata: true } },
+        methods: ["initialize", "status", "chats.list", "messages.history", "messages.after", "messages.stats", "watch.subscribe", "watch.unsubscribe", "send"],
+      };
+      if (request.method === "messages.stats") result = { chats: [{ chat_id: 42, service: "iMessage" }], sent_messages: 1 };
+      if (request.method === "messages.after") {
+        const page = messages.filter((message) => message.id > request.params.since_rowid).slice(0, request.params.limit);
+        result = { messages: page, next_rowid: page.at(-1)?.id ?? request.params.since_rowid,
+          has_more: (page.at(-1)?.id ?? request.params.since_rowid) < count };
+      }
+      if (request.method === "watch.subscribe") result = { subscription: ++subscriptions };
+      process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: request.id, result }) + "\\n");
+      if (request.method === "watch.subscribe" && subscriptions === 1) {
+        for (const message of messages) process.stdout.write(JSON.stringify({ jsonrpc: "2.0",
+          method: "message", params: { subscription: 1, message } }) + "\\n");
+      }
+    `)}
+  `);
+  const messages = createProntoMessages({ imsgPath: executable });
+  const release = Promise.withResolvers<void>();
+  const delivered: number[] = [];
+  let overflows = 0;
+  const subscription = await messages.subscribe({
+    onEvent: async (event) => { delivered.push(event.message.rowId); await release.promise; },
+    onOverflow: () => { overflows += 1; },
+  });
+  try {
+    await Bun.sleep(100);
+    expect(messages.diagnostics().pendingNotifications).toBeLessThanOrEqual(256);
+    release.resolve();
+    const deadline = Date.now() + 25_000;
+    while (delivered.length < count && Date.now() < deadline) await Bun.sleep(10);
+    expect(delivered).toEqual(Array.from({ length: count }, (_, index) => index + 1));
+    expect(overflows).toBeGreaterThan(0);
+  } finally {
+    release.resolve();
+    await subscription.close();
+    await messages.close();
+  }
+}, 30_000);
 
 test("skips stale recovery rows without hiding newer eligible rows", async () => {
   const directory = await fixtureDirectory();

--- a/packages/messages/test/rpc-recovery.test.ts
+++ b/packages/messages/test/rpc-recovery.test.ts
@@ -60,6 +60,74 @@ class FakeConnection implements RpcConnection {
   }
 }
 
+test.each([0, 60_000])("resets reconnect delay after stable health, not a flap (%i ms)", async (healthyMs) => {
+  const connections: FakeConnection[] = [];
+  const delays: number[] = [];
+  let now = 0;
+  const rpc = new ResilientRpcClient({
+    connect: () => { const connection = new FakeConnection(); connections.push(connection); return connection; },
+    now: () => now, random: () => 0.5,
+    wait: async (delay) => { delays.push(delay); },
+  });
+  try {
+    for (let index = 0; index < 2; index += 1) {
+      if (index === 1) now += healthyMs;
+      const restarted = new Promise<void>((resolve) => {
+        const dispose = rpc.onRestart(() => { dispose(); resolve(); });
+      });
+      connections[index]!.fail();
+      await restarted;
+      await rpc.request("status");
+    }
+    expect(delays).toEqual(healthyMs === 0 ? [1_000, 2_000] : [1_000, 1_000]);
+  } finally {
+    await rpc.close();
+  }
+});
+
+test("expires a request while reconnecting without submitting it later", async () => {
+  const connections: FakeConnection[] = [];
+  const resume = Promise.withResolvers<void>();
+  const rpc = new ResilientRpcClient({
+    connect: () => { const connection = new FakeConnection(); connections.push(connection); return connection; },
+    wait: async () => await resume.promise,
+  });
+  try {
+    connections[0]!.fail();
+    const request = rpc.request("send", { text: "never submit this expired request" }, 10)
+      .then(() => "submitted", (error: Error) => error.message);
+    expect(await Promise.race([request, Bun.sleep(100).then(() => "stalled")]))
+      .toBe("imsg RPC request timed out before submission: send");
+    resume.resolve();
+    await rpc.request("status");
+    expect(connections.flatMap((connection) => connection.methods)).not.toContain("send");
+  } finally {
+    resume.resolve();
+    await rpc.close();
+  }
+});
+
+test("retries a failed connection factory without escaping the recovery loop", async () => {
+  const first = new FakeConnection();
+  let calls = 0;
+  const rpc = new ResilientRpcClient({
+    connect: () => {
+      calls += 1;
+      if (calls === 1) return first;
+      if (calls === 2) throw new Error("synthetic spawn failure");
+      return new FakeConnection();
+    },
+    wait: async () => undefined,
+  });
+  try {
+    first.fail();
+    await expect(rpc.request("status")).resolves.toEqual({ protocol_version: 1 });
+    expect(calls).toBe(3);
+  } finally {
+    await rpc.close();
+  }
+});
+
 test("restarts the provider but never replays an already submitted send", async () => {
   const connections: FakeConnection[] = [];
   const rpc = new ResilientRpcClient({

--- a/packages/messages/test/scoped-access.test.ts
+++ b/packages/messages/test/scoped-access.test.ts
@@ -164,6 +164,24 @@ const historyBudget = {
   maxRpcCalls: 1,
 } as const;
 
+test("reads one observed row without scanning the conversation from its beginning", async () => {
+  const directory = await fixtureDirectory();
+  const databasePath = join(directory, "chat.db");
+  await writeFile(databasePath, "database evidence");
+  const messages = await scopedClient({ databasePath, event: observedEvent });
+  try {
+    const observed = await nextEvent(messages);
+    const page = await messages.history({
+      conversation: observed.conversation, mode: "forward", afterRowId: 100,
+      budget: { maxMessages: 1, maxRows: 1, maxRpcCalls: 1, maxBytes: 8_192 },
+    });
+    expect(page.messages.map((event) => event.message.providerMessageId)).toEqual(["observed-guid"]);
+    expect(page.scannedRows).toBe(1);
+  } finally {
+    await messages.close();
+  }
+});
+
 test("a keyed conversation reference survives a client restart", async () => {
   const directory = await fixtureDirectory();
   const databasePath = join(directory, "chat.db");
@@ -192,6 +210,33 @@ test("a keyed conversation reference survives a client restart", async () => {
   await expect(wrongKey.reply({ conversation: observed.conversation, text: "reject" }))
     .rejects.toThrow("messages_conversation_reference_invalid");
   await wrongKey.close();
+});
+
+test("rejects invalid or ambiguous forward positions before spending history budget", async () => {
+  const directory = await fixtureDirectory();
+  const databasePath = join(directory, "chat.db");
+  await writeFile(databasePath, "database evidence");
+  const messages = await scopedClient({ databasePath, event: observedEvent });
+  try {
+    const observed = await nextEvent(messages);
+    for (const position of [
+      { afterRowId: -1, mode: "forward" },
+      { afterRowId: 1.5, mode: "forward" },
+      { afterRowId: Number.NaN, mode: "forward" },
+      { afterRowId: 100, mode: "recent" },
+      { afterRowId: 100 },
+      { afterRowId: 100, mode: "forward", continuation: "not-a-cursor" },
+    ] as const) {
+      await expect(messages.history({
+        ...position, conversation: observed.conversation, budget: historyBudget,
+      })).rejects.toThrow("messages_history_position_invalid");
+    }
+    const result = await messages.history({ conversation: observed.conversation,
+      mode: "forward", afterRowId: 100, budget: historyBudget });
+    expect(result.messages[0]?.message.providerMessageId).toBe("observed-guid");
+  } finally {
+    await messages.close();
+  }
 });
 
 test("sealed conversation history preserves reactions, previews, pagination, and scope", async () => {

--- a/scripts/release-validate.ts
+++ b/scripts/release-validate.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import packageJson from "../package.json" with { type: "json" };
 import messagesPackageJson from "../packages/messages/package.json" with { type: "json" };
+import cliPackageJson from "../packages/cli/package.json" with { type: "json" };
 import { providerOwnershipViolations } from "./provider-ownership";
 import { releaseWorkflowViolations } from "./release-workflow-validation";
 import { mutableActionReferences } from "./workflow-validation";
@@ -28,6 +29,9 @@ async function sourceFiles(directory: string): Promise<string[]> {
 }
 
 const failures: string[] = [];
+if (cliPackageJson.version !== packageJson.version || messagesPackageJson.version !== packageJson.version) {
+  failures.push("workspace, CLI and Messages package versions must agree");
+}
 const workflowPaths = [
   ".github/workflows/ci.yml",
   ".github/workflows/pages.yml",
@@ -101,8 +105,12 @@ for (const [path, args] of [
     stderr: "pipe",
     stdout: "pipe",
   });
-  if (await command.exited !== 0) {
+  const [exitCode, output] = await Promise.all([command.exited, new Response(command.stdout).text()]);
+  if (exitCode !== 0) {
     failures.push(`${path} ${args.join(" ")} failed after compilation`);
+  }
+  if (args[0] === "--version" && output.trim() !== `pronto ${packageJson.version}`) {
+    failures.push("compiled Pronto version does not match the release package");
   }
 }
 failures.push(...await providerOwnershipViolations(root));

--- a/scripts/release-workflow-validation.ts
+++ b/scripts/release-workflow-validation.ts
@@ -17,6 +17,11 @@ const REQUIRED_CONTROLS = [
   ["bun scripts/generate-update-manifest.ts", "signed update manifest generation"],
   ["actions/attest-build-provenance@", "artifact provenance attestation"],
   ["workflow_dispatch:", "manual immutable-tag recovery"],
+  ["- \"!v*-candidate.*\"", "candidate tag push exclusion"],
+  ["candidate_only:", "explicit candidate-only input"],
+  ["if: ${{ inputs.candidate_only != true && !contains(github.ref_name, '-candidate.') }}", "candidate publication fence"],
+  ["- name: Verify owner qualification is complete\n        if: ${{ inputs.candidate_only != true }}", "normal-release owner qualification gate"],
+  ["- name: Create signed update manifest and checksums\n        if: ${{ inputs.candidate_only != true }}", "candidate update-manifest fence"],
   [
     "ref: ${{ github.ref }}",
     "tag-pinned recovery checkout",

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { createConfig, saveConfig, UNRESTRICTED_TRUST_VERSION } from "../../packages/cli/src/config";
 import { pathsForHome } from "../../packages/cli/src/macos/paths";
 import { renderCompatibilityLauncher } from "../../packages/cli/src/compatibility";
+import cliPackage from "../../packages/cli/package.json";
 
 const temporaryDirectories: string[] = [];
 
@@ -36,7 +37,7 @@ describe("Pronto CLI", () => {
     ]);
 
     expect(exitCode).toBe(0);
-    expect(stdout.trim()).toBe("pronto 0.3.0");
+    expect(stdout.trim()).toBe(`pronto ${cliPackage.version}`);
   });
 
   test("the legacy command explains the rename and delegates safe commands", async () => {
@@ -54,7 +55,7 @@ describe("Pronto CLI", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr.trim()).toBe("s4imsg is now Pronto; use the pronto command.");
-    expect(stdout.trim()).toBe("pronto 0.3.0");
+    expect(stdout.trim()).toBe(`pronto ${cliPackage.version}`);
   });
 
   test("the legacy command refuses to start a second foreground listener", async () => {

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -8,6 +8,25 @@ async function releaseWorkflow(): Promise<string> {
 }
 
 describe("release workflow", () => {
+  test("candidate-only signing cannot enter either public publication path", async () => {
+    const workflow = await releaseWorkflow();
+    expect(workflow).toContain("candidate_only:");
+    expect(workflow).toContain("type: boolean");
+    expect(workflow).toContain("default: false");
+    expect(workflow).toContain("- \"!v*-candidate.*\"");
+    expect(workflow).toContain("name: Build candidate checksums");
+    expect(releaseWorkflowViolations(workflow)).toEqual([]);
+    for (const guardedStep of ["Verify owner qualification is complete", "Create signed update manifest and checksums"]) {
+      expect(releaseWorkflowViolations(workflow.replace(
+        `- name: ${guardedStep}\n        if: \${{ inputs.candidate_only != true }}`,
+        `- name: ${guardedStep}`,
+      ))).not.toEqual([]);
+    }
+    expect(releaseWorkflowViolations(workflow.replace(
+      "if: ${{ inputs.candidate_only != true && !contains(github.ref_name, '-candidate.') }}", "if: always()",
+    ))).not.toEqual([]);
+  });
+
   test("uses draft-aware release lookups before publishing", async () => {
     const workflow = await releaseWorkflow();
     const beforePublish = workflow.split("      - name: Publish verified release")[0]!;


### PR DESCRIPTION
Repairs delayed-arrival eligibility, bounds pending notifications, resets stable reconnect backoff, and applies caller deadlines while reconnecting. Adds capability-negotiated positioned scoped history for content-free consumer replay. Adds an explicit candidate-only protected signing path that cannot publish npm packages, GitHub releases, or updater manifests. Prepares version 0.4.0; fresh owner smoke remains required before public release. Validation: typecheck, build, 256 tests, offline packed Node/Bun consumer validation, workflow guard regressions, YAML and shell syntax. No live message or installed daemon change has occurred. Review evidence is in docs/analysis/2026-09-04-reliability-review.md.