### PR TITLE
Fix active-turn shutdown before v0.4.0 promotion

### DIFF
--- a/docs/RELEASE_QUALIFICATION.md
+++ b/docs/RELEASE_QUALIFICATION.md
@@ -3,11 +3,25 @@
 Public release requires every automated gate and an owner-run live smoke. This
 file records capability evidence, not private conversation data.
 
-The matrix below is historical v0.3.0 evidence. The v0.4.0 candidate has not yet
-passed fresh owner smoke or signed-to-signed replacement qualification. Its
-candidate-only CI build may run; public v0.4.0 release remains blocked until this
-matrix is updated with actual evidence. Never carry the v0.3.0 remote smoke
-forward across the v0.4.0 message-transport changes.
+The matrix below is historical v0.3.0 evidence. The v0.4.0 candidate.1 passed
+fresh self/remote replies, self-chat recent context, tagged memory beyond 32
+untagged messages and an idle restart on 2026-09-04. Active-turn replacement
+failed: launchd interrupted the synthetic turn before drain. The installer
+refused replacement and restored the listener; the uncertain synthetic turn
+remains parked without replay. Candidate.1 must not be promoted. A new candidate
+with bounded shutdown qualification is required; public v0.4.0 remains blocked.
+Never carry v0.3.0 remote evidence across v0.4.0's message-transport changes.
+
+Candidate.1 source: `e694dcb15b2342b3b88b344912eb98abb59dcba1`, protected CI run
+`33931479985`; arm64 SHA-256
+`1d1590881a567bbd4f0b2b5711da011deaba7fb9c38f4de1ae4c85543b37814a`.
+Both architectures passed checksum and Developer ID designated-requirement
+verification. CI required notarization submit and log status Accepted. The
+installed launchd candidate retained Full Disk Access and passed doctor, with
+Codex 0.153.0 and imsg 0.14.1 (both CLI version and qualified protocol response).
+The historical matrix's imsg 0.15.0 is not this candidate's live provider version.
+No automated follow-up messages were sent to the remote chat; the owner directed
+context, memory and updater tests to self-chat only.
 
 ## Current matrix
 

--- a/docs/UPDATES.md
+++ b/docs/UPDATES.md
@@ -59,6 +59,16 @@ and waits for content-free health. Failure restores the last-known-good binary
 and configuration. The old updater process remains alive during this transaction,
 so it can roll back even when the candidate cannot start.
 
+The listener's LaunchAgent declares a finite 120-second exit window. Shutdown
+quiesces activation immediately and drains only the current turn; unstarted
+receipts remain durable for the next listener. The unload helper waits up to
+125 seconds for launchd to finish, rather than reporting failure after five
+seconds while drain is still in progress. A turn exceeding the exit window may
+be interrupted and must remain parked when its effects are unknown, never
+automatically replayed. Reinstall the generated LaunchAgent during the initial
+upgrade so the explicit bound applies; an older loaded plist retains launchd's
+implicit deadline until replacement. No persistent launchd disable flag is used.
+
 ## Release credentials
 
 The public repository contains only the public manifest key, Team ID, signing

--- a/docs/analysis/2026-09-04-reliability-review.md
+++ b/docs/analysis/2026-09-04-reliability-review.md
@@ -15,3 +15,26 @@ Regressions cover delayed live callbacks, bounded 10,000-notification recovery, 
 The exact candidate has not completed owner live smoke or signed-to-signed replacement. Historical v0.3.0 evidence cannot qualify changed v0.4.0 transport. Candidate artifacts are for qualification only; the public release gate deliberately still fails for v0.4.0. No real message was sent during local verification. Downstream durable-worker crash-boundary qualification and exact published-version adoption remain separate work, not established by these provider tests.
 
 Summary: Standards 0 unresolved blocking findings; Spec 1 release-blocking qualification gap (fresh signed-candidate owner smoke). Local typecheck/build, 256 tests and offline release validation passed before candidate publication; the protected CI run must independently repeat them.
+
+## Active-drain follow-up review
+
+The live candidate-1 updater check exposed a release-blocking shutdown defect,
+not a failed Messages transport or authorization check. A real launchd fixture
+reproduced the interrupted child with the generated plist. The selected fix
+declares a finite 120-second exit window and a matching 125-second unload wait,
+quiesces the coordinator synchronously on shutdown, and leaves unstarted work
+durable. The native fixture now drains a 25-second child successfully; the
+SQLite lifecycle regression drains one active turn, rejects a racing arrival,
+and retains the next queued receipt. A shutdown already requested during startup
+also quiesces before recovering/scheduling the queue.
+
+Standards: no new IPC, persistent disable flag, task framework, stored message
+format, provider ownership change or automatic replay is introduced. Existing
+unknown-effect recovery remains authoritative. Native tests use only an isolated
+task-owned LaunchAgent and opt in explicitly because hosted runners may lack a
+GUI domain. Unchanged user research is excluded from the commit.
+
+Spec: native and lifecycle regressions pass. Candidate 1 is now disqualified;
+the runtime change requires a new signed candidate and fresh live qualification.
+The finite bound does not promise completion of arbitrarily long requests:
+interrupted unknown effects must still park. Public release remains blocked.

--- a/packages/cli/src/core/daemon.ts
+++ b/packages/cli/src/core/daemon.ts
@@ -100,6 +100,7 @@ export class ProntoDaemon {
         journal,
         this.config.chatKeySalt,
       );
+      if (this.#stopRequested) coordinator.quiesce();
       const recovered = coordinator.start();
       journal.recordDegradedCapabilities(qualification.degraded);
       journal.recordDaemonHealth("ready");
@@ -114,6 +115,7 @@ export class ProntoDaemon {
 
       const stopSignal = new Promise<"stop">((resolve) => {
         this.#stop = () => {
+          coordinator.quiesce();
           resolve("stop");
         };
         if (this.#stopRequested) this.#stop();

--- a/packages/cli/src/core/turn.ts
+++ b/packages/cli/src/core/turn.ts
@@ -380,6 +380,7 @@ export class TurnProcessor {
 
 export class TurnCoordinator {
   #draining: Promise<void> | null = null;
+  #quiesced = false;
 
   constructor(
     readonly processor: TurnProcessor,
@@ -394,6 +395,7 @@ export class TurnCoordinator {
   }
 
   admit(request: ActivatedRequest): "accepted" | "duplicate" | "rate-limited" {
+    if (this.#quiesced) throw new Error("turn_coordinator_quiesced");
     const result = this.journal.admit({
       activationTag: request.activationTag,
       chatId: request.chatId,
@@ -410,16 +412,20 @@ export class TurnCoordinator {
     while (this.#draining !== null) await this.#draining;
   }
 
+  quiesce(): void {
+    this.#quiesced = true;
+  }
+
   #schedule(): void {
-    if (this.#draining !== null) return;
+    if (this.#draining !== null || this.#quiesced) return;
     this.#draining = this.#drain().finally(() => {
       this.#draining = null;
-      if (this.journal.nextRunnable() !== null) this.#schedule();
+      if (!this.#quiesced && this.journal.nextRunnable() !== null) this.#schedule();
     });
   }
 
   async #drain(): Promise<void> {
-    while (true) {
+    while (!this.#quiesced) {
       const event = this.journal.nextRunnable();
       if (event === null) return;
       await this.processor.process(event);

--- a/packages/cli/src/macos/launch-agent.ts
+++ b/packages/cli/src/macos/launch-agent.ts
@@ -12,7 +12,8 @@ export interface ProcessResult {
 export type LaunchctlRunner = (args: readonly string[]) => Promise<ProcessResult>;
 
 const BOOTOUT_POLL_INTERVAL_MS = 100;
-const BOOTOUT_POLL_ATTEMPTS = 50;
+const LAUNCH_AGENT_DRAIN_SECONDS = 120;
+const BOOTOUT_POLL_ATTEMPTS = LAUNCH_AGENT_DRAIN_SECONDS * 10 + 50;
 
 export type LaunchAgentState = "running" | "loaded" | "stopped";
 
@@ -76,6 +77,8 @@ export function renderLaunchAgent(input: {
   <true/>
   <key>KeepAlive</key>
   <true/>
+  <key>ExitTimeOut</key>
+  <integer>${LAUNCH_AGENT_DRAIN_SECONDS}</integer>
   <key>ProcessType</key>
   <string>Background</string>
   <key>StandardOutPath</key>

--- a/test/integration/launchd-drain.test.ts
+++ b/test/integration/launchd-drain.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { renderLaunchAgent, runLaunchctl, stopLaunchAgentForLabel } from "../../packages/cli/src/macos/launch-agent";
+
+// Native lifecycle qualification, opt-in because hosted CI may have no GUI domain.
+// No Messages, credentials, models, or production LaunchAgent participates.
+test.skipIf(process.platform !== "darwin" || process.env.RUN_LAUNCHD_INTEGRATION !== "1")(
+  "graceful unload lets the active child finish beyond launchd's exit deadline",
+  async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pronto-launchd-drain-"));
+    const label = `dev.pronto.test.${randomUUID()}`;
+    const uid = process.getuid!();
+    const service = `gui/${uid}/${label}`;
+    const marker = join(directory, "state.json");
+    const fixture = join(directory, "fixture.ts");
+    const plist = join(directory, "fixture.plist");
+    try {
+      await writeFile(fixture, `
+        const marker = ${JSON.stringify(marker)};
+        const child = Bun.spawn([process.execPath, "-e", "await Bun.sleep(25000)"], {stdout:"ignore",stderr:"ignore"});
+        let stop;
+        const stopped = new Promise(resolve => {stop=resolve;});
+        process.once("SIGTERM", () => stop());
+        await Bun.write(marker, JSON.stringify({state:"active",pid:process.pid,child:child.pid}));
+        await stopped;
+        const exitCode = await child.exited;
+        await Bun.write(marker, JSON.stringify({state:"drained",exitCode,pid:process.pid}));
+      `, { mode: 0o600 });
+      const rendered = renderLaunchAgent({ executablePath: process.execPath,
+        logPath: join(directory, "fixture.log"), runtimeExecutablePaths: [] })
+        .replace("dev.pronto.agent", label)
+        .replace("<string>run</string>", `<string>${fixture}</string>`);
+      await writeFile(plist, rendered, { mode: 0o600 });
+      await chmod(directory, 0o700);
+      const boot = await runLaunchctl(["bootstrap", `gui/${uid}`, plist]);
+      expect(boot.exitCode).toBe(0);
+      for (let attempt = 0; attempt < 100; attempt++) {
+        const state = await readFile(marker, "utf8").catch(() => "");
+        if (state.includes('"active"')) break;
+        await Bun.sleep(25);
+      }
+      expect(JSON.parse(await readFile(marker, "utf8")).state).toBe("active");
+      await stopLaunchAgentForLabel({ label, uid });
+      expect(JSON.parse(await readFile(marker, "utf8"))).toMatchObject({ state: "drained", exitCode: 0 });
+      expect((await runLaunchctl(["print", service])).exitCode).not.toBe(0);
+    } finally {
+      await runLaunchctl(["bootout", service]);
+      await runLaunchctl(["enable", service]);
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+  45_000,
+);

--- a/test/integration/turn-lifecycle.test.ts
+++ b/test/integration/turn-lifecycle.test.ts
@@ -149,6 +149,36 @@ async function harness(primary: RuntimeAdapter, fallback?: RuntimeAdapter) {
 }
 
 describe("turn lifecycle", () => {
+  test("quiescing drains the active turn but preserves unstarted work for restart", async () => {
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const adapter: RuntimeAdapter = {
+      kind: "codex", executablePath: "/usr/local/bin/fixture",
+      run: async () => {
+        entered.resolve();
+        await release.promise;
+        return { status: "success", toolActivity: "none", output: { reply: "first reply" } };
+      },
+    };
+    const h = await harness(adapter);
+    try {
+      h.coordinator.admit({ ...activation, providerGuid: "DRAIN-1" });
+      await entered.promise;
+      h.coordinator.admit({ ...activation, providerGuid: "DRAIN-2" });
+      h.coordinator.quiesce();
+      expect(() => h.coordinator.admit({ ...activation, providerGuid: "DRAIN-3" }))
+        .toThrow("turn_coordinator_quiesced");
+      release.resolve();
+      await h.coordinator.idle();
+      expect(h.transport.sends).toHaveLength(1);
+      expect(h.journal.nextRunnable()?.providerGuid).toBe("DRAIN-2");
+    } finally {
+      release.resolve();
+      await h.coordinator.idle();
+      h.close();
+    }
+  });
+
   test("switches only on explicit intent and makes the folder durable after delivery", async () => {
     const primary = new FakeAdapter("codex", {
       output: { reply: "Working there." },

--- a/test/unit/launch-agent.test.ts
+++ b/test/unit/launch-agent.test.ts
@@ -36,6 +36,7 @@ test("renders a stable owner LaunchAgent without shell interpolation", () => {
 
   expect(plist).toContain("dev.pronto.agent");
   expect(plist).toContain("<string>run</string>");
+  expect(plist).toContain("<key>ExitTimeOut</key>\n  <integer>120</integer>");
   expect(plist).toContain("agent &amp; output.log");
   expect(plist).toContain(
     "<string>/opt/homebrew/bin:/Users/me/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>",
@@ -292,11 +293,11 @@ test("keeps the replacement plist and does not bootstrap when bootout times out"
     }),
   ).rejects.toThrow("run setup again");
 
-  expect(calls.filter(([command]) => command === "print")).toHaveLength(50);
+  expect(calls.filter(([command]) => command === "print")).toHaveLength(1_250);
   expect(calls.some(([command]) => command === "bootstrap" || command === "kickstart")).toBe(
     false,
   );
-  expect(waits).toHaveLength(49);
+  expect(waits).toHaveLength(1_249);
   expect(await readFile(plistPath, "utf8")).toContain("<plist>");
 });
 


### PR DESCRIPTION
## Summary

The signed candidate's owner-authorized self-chat updater test exposed an active-turn shutdown failure: launchd's implicit exit deadline interrupted the runtime before it drained. The qualification installer refused replacement, restored the listener, and retained the uncertain synthetic turn without replay.

- Declare a finite 120-second LaunchAgent exit window and match it with a 125-second unload wait.
- Quiesce activation synchronously on shutdown, drain only the active turn, and leave unstarted receipts durable for restart.
- Preserve unknown-effect parking; do not introduce persistent launchd disable state.
- Disqualify candidate 1 in the evidence until a new signed candidate passes fresh qualification.

## Verification

- Native launchd regression failed with the original generated plist; passed with a real 25-second child after the fix (26.5 seconds). Run with `RUN_LAUNCHD_INTEGRATION=1 bun test test/integration/launchd-drain.test.ts`. The fixture uses no Messages, model, credentials or production LaunchAgent.
- SQLite lifecycle regression failed before quiesce existed; now drains the active turn, rejects racing intake, and retains the next unstarted request.
- 257 tests passed; the native GUI-domain test is opt-in and was run separately.
- Typecheck, build, and offline packed Node/Bun release validation passed.

Public v0.4.0 publication remains blocked. This PR requires a new immutable candidate tag, protected signing, and fresh live qualification. Long-running work exceeding the finite exit window may still be interrupted and conservatively parked; no arbitrary-duration completion guarantee is claimed.
