### PR TITLE
Recover timed-out catch-up and report truthful listener readiness

### DIFF
--- a/docs/RELEASE_QUALIFICATION.md
+++ b/docs/RELEASE_QUALIFICATION.md
@@ -23,6 +23,24 @@ The historical matrix's imsg 0.15.0 is not this candidate's live provider versio
 No automated follow-up messages were sent to the remote chat; the owner directed
 context, memory and updater tests to self-chat only.
 
+Candidate.2 source: `a4991b1a21af2eae4961fcb6fde0896401ca4bb6`, protected CI run
+`33934137599`; arm64 SHA-256
+`fe78274ffe9786ed910764849d1677ca7125553ec7b77d51d2107e599ea8f0d2`.
+Checksums, both Developer ID requirements, notarization, packed Node/Bun imports
+and installed doctor passed. Active-turn signed replacement completed with one
+confirmed synthetic reply and returned to ready; the previous uncertain event
+remained parked without replay. Fresh self-chat recent context and tagged memory
+save also passed, with one confirmed send each. No automated remote messages
+were sent.
+
+After 32 new untagged self-chat messages and an idle restart, the new recall
+request was visible in Messages but absent from the journal. The log reported
+duration-limit while status falsely reported ready. Candidate.2 is therefore
+also disqualified. Local regressions cover readiness before subscription,
+persisted recovery degradation, and checkpoint retry after a catch-up deadline.
+Those runtime changes require another immutable signed candidate and fresh
+qualification. Public v0.4.0 remains blocked; the matrix below remains historical.
+
 ## Current matrix
 
 | Surface | Qualified version | Evidence | Status |

--- a/docs/UPDATES.md
+++ b/docs/UPDATES.md
@@ -59,11 +59,13 @@ and waits for content-free health. Failure restores the last-known-good binary
 and configuration. The old updater process remains alive during this transaction,
 so it can roll back even when the candidate cannot start.
 
-The listener's LaunchAgent declares a finite 120-second exit window. Shutdown
+The listener's LaunchAgent requests a finite 120-second exit window; launchd may
+apply a shorter effective limit (60 seconds was reported on macOS 26.5.1 during
+candidate-2 qualification). Shutdown
 quiesces activation immediately and drains only the current turn; unstarted
 receipts remain durable for the next listener. The unload helper waits up to
 125 seconds for launchd to finish, rather than reporting failure after five
-seconds while drain is still in progress. A turn exceeding the exit window may
+seconds while drain is still in progress. A turn exceeding the effective exit window may
 be interrupted and must remain parked when its effects are unknown, never
 automatically replayed. Reinstall the generated LaunchAgent during the initial
 upgrade so the explicit bound applies; an older loaded plist retains launchd's

--- a/docs/analysis/2026-09-04-reliability-review.md
+++ b/docs/analysis/2026-09-04-reliability-review.md
@@ -38,3 +38,34 @@ Spec: native and lifecycle regressions pass. Candidate 1 is now disqualified;
 the runtime change requires a new signed candidate and fresh live qualification.
 The finite bound does not promise completion of arbitrarily long requests:
 interrupted unknown effects must still park. Public release remains blocked.
+
+## Readiness and catch-up follow-up review
+
+Baseline for this slice: `a4991b1a21af2eae4961fcb6fde0896401ca4bb6` (candidate 2).
+The live restart check exposed a second blocker: catch-up timed out and left a
+new self-chat request unadmitted while daemon status remained ready. Synthetic
+public-module and real daemon/journal fixtures reproduced the two symptoms.
+
+Standards: provider retry remains inside the independent Messages module. There
+is one scheduled checkpoint retry per subscription, bounded backoff, close-aware
+timer cleanup and unchanged generation/age fences. Completed recovery rows retain
+their cumulative budget across timeout retries. No provider send or unknown
+consumer effect is automatically retried. No raw RPC ownership moves downstream;
+the daemon consumes recovery events through its existing adapter. Logs/status
+carry only bounded reason codes. Unrelated research and Studio UI work are excluded.
+
+Spec: startup clears stale readiness and waits for subscription; recovery
+degradation is durable and is not overwritten by ready. The new retry regression
+delivers its pending synthetic message exactly once; close cancels a pending
+retry. Recovery success is reported after watch subscription, retaining row
+accounting even when the first resubscribe fails. The public action union adds
+`retrying-checkpoint`; the documented duration is per attempt, not a guarantee of
+overall catch-up completion. Existing row/generation terminal boundaries remain.
+Studio's adapter inspects status/reason, not an exhaustive action switch, but its
+exact released dependency adoption still needs cross-repo verification. Candidate
+2 cannot qualify these runtime changes; signed/live qualification remains open.
+
+Verification: 261 tests passed, one native test skipped by default; typecheck,
+build and offline packed-release validation passed. The native active-drain test
+passed before this slice and candidate 2's actual active replacement succeeded.
+It must still be repeated on the next signed runtime candidate.

--- a/docs/analysis/2026-09-04-reliability-review.md
+++ b/docs/analysis/2026-09-04-reliability-review.md
@@ -69,3 +69,9 @@ Verification: 261 tests passed, one native test skipped by default; typecheck,
 build and offline packed-release validation passed. The native active-drain test
 passed before this slice and candidate 2's actual active replacement succeeded.
 It must still be repeated on the next signed runtime candidate.
+
+Native follow-up: one invocation failed before the synthetic process created its
+startup marker within 2.5 seconds; the unchanged rerun drained successfully in
+27 seconds. The fixture now allows a bounded 10-second startup wait while keeping
+the same active-child completion and unloaded-service assertions. This changes
+test startup tolerance, not the product's shutdown deadline.

--- a/packages/cli/src/core/daemon.ts
+++ b/packages/cli/src/core/daemon.ts
@@ -57,6 +57,7 @@ export class ProntoDaemon {
   async run(): Promise<void> {
     const database = openProntoDatabase(this.paths.databasePath);
     const journal = new DeliveryJournal(database);
+    journal.recordDaemonHealth("starting");
     const legacyUnscopedCursor = journal.cursor();
     const messages = createProntoMessages(standaloneMessagesOptions({
       chatKeySalt: this.config.chatKeySalt,
@@ -103,15 +104,17 @@ export class ProntoDaemon {
       if (this.#stopRequested) coordinator.quiesce();
       const recovered = coordinator.start();
       journal.recordDegradedCapabilities(qualification.degraded);
-      journal.recordDaemonHealth("ready");
-      console.log(
-        JSON.stringify({
-          component: "daemon",
-          degradedCapabilities: qualification.degraded,
-          recovery: recovered,
-          state: "ready",
-        }),
-      );
+      let subscriptionReady = false;
+      let recoveryReason: string | undefined;
+      const updateHealth = () => {
+        if (this.#stopRequested) return;
+        journal.recordDaemonHealth(recoveryReason !== undefined
+          ? "degraded" : subscriptionReady ? "ready" : "starting");
+        journal.recordDegradedCapabilities([
+          ...qualification.degraded,
+          ...(recoveryReason === undefined ? [] : [`messages-recovery-${recoveryReason}`]),
+        ]);
+      };
 
       const stopSignal = new Promise<"stop">((resolve) => {
         this.#stop = () => {
@@ -125,8 +128,22 @@ export class ProntoDaemon {
           coordinator.admit(request);
         },
         onMessageRowId: (rowId) => journal.advanceCursor(rowId),
+        onRecovery: (outcome) => {
+          recoveryReason = outcome.status === "degraded" ? outcome.reason : undefined;
+          updateHealth();
+        },
         tags: this.config.tags,
       });
+      subscriptionReady = true;
+      updateHealth();
+      if (!this.#stopRequested) {
+        console.log(JSON.stringify({
+          component: "daemon",
+          degradedCapabilities: journal.degradedCapabilities(),
+          recovery: recovered,
+          state: journal.daemonHealth()?.state,
+        }));
+      }
       const outcome = await Promise.race([
         stopSignal,
         activeWatch.terminated.then(() => "transport-closed" as const),

--- a/packages/cli/src/imessage/transport.ts
+++ b/packages/cli/src/imessage/transport.ts
@@ -3,6 +3,7 @@ import type {
   ConversationFacts,
   ConversationReference,
   MessagesEvent,
+  MessagesRecoveryOutcome,
   MessagesSubscription,
   ProntoMessages,
 } from "pronto-imessage";
@@ -76,6 +77,7 @@ export class ImsgTransport {
   async watch(input: {
     onActivation: (request: ActivatedRequest) => void | Promise<void>;
     onMessageRowId?: (rowId: number) => void | Promise<void>;
+    onRecovery?: (outcome: MessagesRecoveryOutcome) => void | Promise<void>;
     tags: readonly string[];
   }): Promise<MessagesSubscription> {
     return await this.messages.subscribe({
@@ -84,7 +86,8 @@ export class ImsgTransport {
         if (request !== null) await input.onActivation(request);
         await input.onMessageRowId?.(event.message.rowId);
       },
-      onRecovery: (outcome) => {
+      onRecovery: async (outcome) => {
+        await input.onRecovery?.(outcome);
         console.error(JSON.stringify({
           component: "pronto-messages",
           ...(outcome.status === "degraded" ? { reason: outcome.reason } : {}),

--- a/packages/cli/src/storage/journal.ts
+++ b/packages/cli/src/storage/journal.ts
@@ -45,7 +45,7 @@ export interface OperationalStatus {
 }
 
 export interface DaemonHealth {
-  state: "failed" | "ready" | "stopped";
+  state: "starting" | "degraded" | "failed" | "ready" | "stopped";
   updatedAt: number;
 }
 
@@ -225,7 +225,7 @@ export class DeliveryJournal {
     const state = values.get("daemon_state");
     const updatedAt = Number(values.get("daemon_updated_at"));
     if (
-      (state !== "failed" && state !== "ready" && state !== "stopped") ||
+      (state !== "starting" && state !== "degraded" && state !== "failed" && state !== "ready" && state !== "stopped") ||
       !Number.isSafeInteger(updatedAt) ||
       updatedAt <= 0
     ) {

--- a/packages/messages/README.md
+++ b/packages/messages/README.md
@@ -35,7 +35,7 @@ const subscription = await messages.subscribe({
   },
   onRecovery: async (outcome) => {
     if (outcome.status === "degraded") {
-      // Continue with live events and surface outcome.reason to the owner.
+      // Surface outcome.reason; retrying-checkpoint is not ready for live events.
     }
   },
 });
@@ -49,6 +49,15 @@ still present; otherwise it returns a structured rejection. An existing Pronto
 checkpoint is always preserved.
 
 The package binds durable checkpoints to a fingerprint of the current Messages database. It restarts and resubscribes after provider failure, performs catch-up within row-count, age, and wall-clock limits, skips stale recovery rows without hiding newer eligible rows, and rejects stale live notifications. The recovery and live age limits are independently configurable with `recoveryLimits.maxAgeMs` and `recoveryLimits.maxLiveAgeMs`. A send that may have reached the provider is returned as `ambiguous` and is never automatically replayed.
+
+`maxDurationMs` bounds each catch-up attempt. A duration timeout reports
+`action: "retrying-checkpoint"` and retries from the durable checkpoint with
+250 ms–30 s backoff instead of switching to future-only events. Completed rows
+continue to consume the recovery row budget across those retries. Successful
+recovery is reported only after watch subscription succeeds. Close cancels a
+pending retry; row-limit and database-identity boundaries retain their explicit
+live-only/fail-closed behavior. An in-flight consumer callback is awaited, not
+concurrently replayed, before checkpoint recovery proceeds.
 
 Every observed conversation carries a module-issued, versioned, tamper-evident reference with an expiry. References are process-local by default. A consumer with durable queued work can provide a stable owner-private `referenceKey` of at least 32 bytes; that permits an unexpired observed reference to be revalidated after restart without granting access to a different chat. Rotating the key invalidates outstanding references. History requires that exact reference plus an explicit message, row, byte, and RPC-call budget. Pagination continuations remain bound to the same conversation capability and database generation. They cannot be used to search another conversation.
 

--- a/packages/messages/src/index.ts
+++ b/packages/messages/src/index.ts
@@ -284,6 +284,29 @@ class ProntoMessagesClient implements ProntoMessages {
     const pendingNotifications: { notification: RpcNotification; arrivedAt: number }[] = [];
     let notificationDrainScheduled = false;
     let notificationOverflowed = false;
+    let recoveryRetryScheduled = false;
+    let recoveryRetryDelayMs = 250;
+    let unreportedRecoveryRows = 0;
+    let recoveryRowsUsed = 0;
+    const scheduleRecoveryRetry = (): void => {
+      if (closed || recoveryRetryScheduled) return;
+      recoveryRetryScheduled = true;
+      enqueue(async () => {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        await Promise.race([
+          new Promise<void>((resolve) => {
+            timer = setTimeout(resolve, recoveryRetryDelayMs);
+            timer.unref?.();
+          }),
+          closedSignal,
+        ]);
+        if (timer !== undefined) clearTimeout(timer);
+        recoveryRetryScheduled = false;
+        if (closed) return;
+        recoveryRetryDelayMs = Math.min(30_000, recoveryRetryDelayMs * 2);
+        await recoverUntilSubscribed();
+      });
+    };
     const flushNotifications = (): void => {
       if (notificationDrainScheduled || subscriptionId === null || closed ||
         (pendingNotifications.length === 0 && !notificationOverflowed)) return;
@@ -363,6 +386,7 @@ class ProntoMessagesClient implements ProntoMessages {
         return;
       }
       subscriptionId = result.subscription;
+      recoveryRowsUsed = 0;
       flushNotifications();
     };
     const recover = async (boundaryReason?: MessagesRecoveryReason): Promise<void> => {
@@ -409,20 +433,33 @@ class ProntoMessagesClient implements ProntoMessages {
         await subscribeProvider(false);
         return;
       }
+      let outcome: MessagesRecoveryOutcome | undefined;
       if (previous !== undefined) {
-        const outcome = await this.#catchUp(
+        outcome = await this.#catchUp(
           databaseGeneration,
           input,
           scheduleDeferredDelivery,
+          this.#limits.maxRows - recoveryRowsUsed,
         );
+        recoveryRowsUsed += outcome.rows;
         if (outcome.status === "degraded" && outcome.reason === "database-generation-changed") {
           databaseGeneration = (await this.qualify()).databaseGeneration;
         }
-        await report(outcome);
+        if (outcome.status === "degraded") await report(outcome);
+        else unreportedRecoveryRows += outcome.rows;
         if (this.#inFlightDeliveries.size > 0) return;
+        if (outcome.status === "degraded" && outcome.reason === "duration-limit") {
+          scheduleRecoveryRetry();
+          return;
+        }
       }
-      await subscribeProvider(this.#diagnostics.state !== "degraded");
-      if (this.#diagnostics.state !== "degraded") {
+      await subscribeProvider(outcome?.status !== "degraded");
+      if (outcome?.status === "recovered") {
+        await report({ rows: unreportedRecoveryRows, status: "recovered" });
+        unreportedRecoveryRows = 0;
+      }
+      if (outcome?.status !== "degraded") {
+        recoveryRetryDelayMs = 250;
         this.#diagnostics = { ...this.#diagnostics, state: "ready" };
       }
     };
@@ -812,6 +849,7 @@ class ProntoMessagesClient implements ProntoMessages {
       generation: string,
       error?: unknown,
     ) => void,
+    maxRows = this.#limits.maxRows,
   ): Promise<MessagesRecoveryOutcome> {
     const checkpoint = await this.#state.checkpoint(generation);
     if (checkpoint === undefined) return { rows: 0, status: "recovered" };
@@ -822,7 +860,7 @@ class ProntoMessagesClient implements ProntoMessages {
     try {
       while (true) {
         await this.#assertGeneration(generation, { deadline, rows });
-        const remaining = this.#limits.maxRows - rows;
+        const remaining = maxRows - rows;
         if (remaining <= 0) throw new RecoveryBoundaryError("row-limit", rows);
         const response = record(await this.#withinDeadline({ deadline, rows }, async () =>
           await this.#rpc.request("messages.after", {
@@ -845,7 +883,7 @@ class ProntoMessagesClient implements ProntoMessages {
         ) {
           throw new RecoveryBoundaryError("invalid-provider-page", rows);
         }
-        if (rows + messages.length > this.#limits.maxRows) {
+        if (rows + messages.length > maxRows) {
           throw new RecoveryBoundaryError("row-limit", rows);
         }
         for (const raw of messages) {
@@ -884,7 +922,7 @@ class ProntoMessagesClient implements ProntoMessages {
     } catch (error) {
       if (error instanceof RecoveryBoundaryError) {
         return {
-          action: "live-events-only",
+          action: error.reason === "duration-limit" ? "retrying-checkpoint" : "live-events-only",
           reason: error.reason,
           rows: error.rows,
           status: "degraded",

--- a/packages/messages/src/types.ts
+++ b/packages/messages/src/types.ts
@@ -112,7 +112,7 @@ export type MessagesRecoveryOutcome =
     readonly status: "recovered";
   }
   | {
-    readonly action: "live-events-only";
+    readonly action: "live-events-only" | "retrying-checkpoint";
     readonly reason: MessagesRecoveryReason;
     readonly rows: number;
     readonly status: "degraded";
@@ -132,6 +132,7 @@ export interface MessagesDiagnostics {
 export interface MessagesRecoveryLimits {
   readonly maxLiveAgeMs?: number;
   readonly maxAgeMs?: number;
+  /** Wall-clock budget per catch-up attempt; timed-out attempts retry with backoff. */
   readonly maxDurationMs?: number;
   readonly maxRows?: number;
 }

--- a/packages/messages/test/recovery.test.ts
+++ b/packages/messages/test/recovery.test.ts
@@ -53,6 +53,63 @@ function checkpointWitness(rowId = 40, providerMessageId = "checkpoint-guid") {
   };
 }
 
+test.each([false, true])("timed-out catch-up resumes its checkpoint or closes promptly (close=%s)", async (closeEarly) => {
+  const directory = await fixtureDirectory();
+  const databasePath = join(directory, "chat.db");
+  const statePath = join(directory, "provider-state.json");
+  await writeFile(databasePath, "synthetic database evidence");
+  const generation = await databaseGeneration(databasePath);
+  await new ProviderStateStore(statePath).advance(generation, 40, checkpointWitness());
+  const row = { chat_id: 42, created_at: new Date().toISOString(), guid: "pending-41", id: 41,
+    is_from_me: true, service: "iMessage", text: "synthetic pending request" };
+  const executable = await executableWithSource(directory, `
+    let delayed = false;
+    ${rpcLoop(`
+      let result = { ok: true };
+      if (request.method === "initialize") result = {
+        protocol_version: 1, version: "0.14.1",
+        database: { path: ${JSON.stringify(databasePath)}, ready: true, features: { routing_metadata: true } },
+        methods: ["initialize", "status", "chats.list", "messages.history", "messages.after", "messages.stats", "watch.subscribe", "watch.unsubscribe", "send"],
+      };
+      if (request.method === "messages.after") {
+        const since = request.params.since_rowid;
+        result = since === 39
+          ? { has_more: false, messages: [{ guid: "checkpoint-guid", id: 40 }], next_rowid: 40 }
+          : { has_more: false, messages: since < 41 ? [${JSON.stringify(row)}] : [], next_rowid: Math.max(41, since) };
+      }
+      if (request.method === "messages.stats") {
+        if (!delayed) { delayed = true; await Bun.sleep(200); }
+        result = { chats: [{ chat_id: 42, service: "iMessage" }], sent_messages: 1 };
+      }
+      if (request.method === "watch.subscribe") result = { subscription: 1 };
+      process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: request.id, result }) + "\\n");
+    `)}
+  `);
+  const messages = createProntoMessages({ imsgPath: executable, statePath,
+    recoveryLimits: { maxDurationMs: 50, maxAgeMs: 60_000, maxRows: 10 } });
+  const delivered: number[] = [];
+  const outcomes: MessagesRecoveryOutcome[] = [];
+  let subscription: Awaited<ReturnType<typeof messages.subscribe>> | undefined;
+  try {
+    subscription = await messages.subscribe({ onEvent: (event) => { delivered.push(event.message.rowId); },
+      onRecovery: (outcome) => { outcomes.push(outcome); } });
+    expect(outcomes).toContainEqual(expect.objectContaining({ status: "degraded", reason: "duration-limit", action: "retrying-checkpoint" }));
+    if (closeEarly) {
+      const closingAt = Date.now();
+      await subscription.close();
+      expect(Date.now() - closingAt).toBeLessThan(150);
+      await Bun.sleep(350);
+      expect(delivered).toEqual([]);
+      return;
+    }
+    const deadline = Date.now() + 2_000;
+    while (messages.diagnostics().state !== "ready" && Date.now() < deadline) await Bun.sleep(10);
+    expect(delivered).toEqual([41]);
+    expect(messages.diagnostics().state).toBe("ready");
+    expect(outcomes.at(-1)).toMatchObject({ status: "recovered" });
+  } finally { await subscription?.close(); await messages.close(); }
+});
+
 test("keeps both fresh live messages when the first consumer takes six minutes", async () => {
   const directory = await fixtureDirectory();
   const databasePath = join(directory, "chat.db");

--- a/test/integration/daemon-readiness.test.ts
+++ b/test/integration/daemon-readiness.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createConfig } from "../../packages/cli/src/config";
+import { ProntoDaemon } from "../../packages/cli/src/core/daemon";
+import { pathsForHome } from "../../packages/cli/src/macos/paths";
+import { openProntoDatabase } from "../../packages/cli/src/storage/database";
+import { DeliveryJournal } from "../../packages/cli/src/storage/journal";
+import { createProntoMessages } from "pronto-imessage";
+
+test.each([false, true])("restart waits for subscription and preserves recovery degradation (%s)", async (degraded) => {
+  const directory = await mkdtemp(join(tmpdir(), "pronto-readiness-"));
+  const paths = pathsForHome(directory);
+  const provider = join(directory, "imsg-fixture");
+  const providerDatabase = join(directory, "chat.db");
+  const subscribing = join(directory, "subscribing");
+  const release = join(directory, "release");
+  await writeFile(providerDatabase, "synthetic database identity");
+  await writeFile(provider, `#!/usr/bin/env bun
+    import { writeFileSync, existsSync } from "node:fs";
+    let buffer = "";
+    for await (const chunk of Bun.stdin.stream()) {
+      buffer += new TextDecoder().decode(chunk);
+      while (buffer.includes("\\n")) {
+        const end = buffer.indexOf("\\n");
+        const request = JSON.parse(buffer.slice(0, end));
+        buffer = buffer.slice(end + 1);
+        let result = { ok: true };
+        if (request.method === "initialize") result = {
+          protocol_version: 1, version: "0.14.1",
+          database: { path: ${JSON.stringify(providerDatabase)}, ready: true, features: { routing_metadata: true } },
+          methods: ["initialize", "status", "chats.list", "messages.history", "messages.after", "messages.stats", "watch.subscribe", "watch.unsubscribe", "send"],
+        };
+        if (request.method === "watch.subscribe") {
+          writeFileSync(${JSON.stringify(subscribing)}, "started");
+          while (!existsSync(${JSON.stringify(release)})) await Bun.sleep(5);
+          result = { subscription: 1 };
+        }
+        process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: request.id, result }) + "\\n");
+      }
+    }
+  `, { mode: 0o700 });
+  const database = openProntoDatabase(paths.databasePath);
+  const journal = new DeliveryJournal(database);
+  journal.recordDaemonHealth("ready"); // Prior process's persisted status.
+  if (degraded) {
+    const messages = createProntoMessages({ imsgPath: provider, statePath: paths.providerStatePath });
+    try {
+      const qualified = await messages.qualify();
+      await messages.adoptCheckpoint!({ version: 1, rowId: 0, databaseGeneration: qualified.databaseGeneration });
+    } finally { await messages.close(); }
+  }
+  const daemon = new ProntoDaemon(createConfig({
+    imsgPath: provider, primaryRuntime: "codex", primaryRuntimePath: process.execPath,
+    tags: ["@test"], unrestrictedTrustVersion: 1, workingDirectory: directory,
+  }), paths);
+  const running = daemon.run();
+  try {
+    const deadline = Date.now() + 2_000;
+    while (!await Bun.file(subscribing).exists() && Date.now() < deadline) await Bun.sleep(5);
+    expect(await Bun.file(subscribing).exists()).toBe(true);
+    expect(journal.daemonHealth()?.state).not.toBe("ready");
+    await writeFile(release, "continue");
+    const expected = degraded ? "degraded" : "ready";
+    const readyDeadline = Date.now() + 2_000;
+    while (journal.daemonHealth()?.state !== expected && Date.now() < readyDeadline) await Bun.sleep(5);
+    expect(journal.daemonHealth()?.state).toBe(expected);
+    if (degraded) expect(journal.degradedCapabilities()).toContain("messages-recovery-invalid-provider-page");
+  } finally {
+    await writeFile(release, "continue");
+    daemon.stop();
+    await running;
+    database.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/test/integration/launchd-drain.test.ts
+++ b/test/integration/launchd-drain.test.ts
@@ -37,7 +37,8 @@ test.skipIf(process.platform !== "darwin" || process.env.RUN_LAUNCHD_INTEGRATION
       await chmod(directory, 0o700);
       const boot = await runLaunchctl(["bootstrap", `gui/${uid}`, plist]);
       expect(boot.exitCode).toBe(0);
-      for (let attempt = 0; attempt < 100; attempt++) {
+      const startupDeadline = Date.now() + 10_000;
+      while (Date.now() < startupDeadline) {
         const state = await readFile(marker, "utf8").catch(() => "");
         if (state.includes('"active"')) break;
         await Bun.sleep(25);


### PR DESCRIPTION
## Summary

The second signed candidate passed active-turn replacement, but the next self-chat restart check exposed false readiness and a catch-up deadline dropping a pending request. Candidate 2 remains disqualified.

- Clear persisted readiness at startup and wait for subscription completion.
- Preserve transport degradation in content-free status, including its reason.
- Retry catch-up deadlines from the checkpoint with one close-aware timer and 250 ms–30 s backoff.
- Preserve generation/age fences, completed-row budgets and in-flight callback ownership; do not replay unknown runtime or send effects.
- Report recovery only after watch subscription succeeds. Add the explicit recovery action `retrying-checkpoint` and document per-attempt duration semantics.

## Verification

The gated synthetic provider and real daemon/journal regression failed before the readiness fix. The public-module timeout regression failed before retry was added, and now delivers its pending row once. Close cancels a scheduled retry.

- 261 tests passed, one opt-in native test skipped.
- Typecheck, compiled build and offline packed Node/Bun release validation passed.
- Standards and Spec review recorded in `docs/analysis/2026-09-04-reliability-review.md`.

No real message content, account identifiers or local configuration is included. Public release remains blocked. This runtime change requires a new immutable signed candidate and fresh owner qualification; it must not reuse either disqualified candidate's approval.
