### PR TITLE
Allow bounded checkpoint recovery during update qualification

### DIFF
--- a/docs/RELEASE_QUALIFICATION.md
+++ b/docs/RELEASE_QUALIFICATION.md
@@ -41,6 +41,16 @@ persisted recovery degradation, and checkpoint retry after a catch-up deadline.
 Those runtime changes require another immutable signed candidate and fresh
 qualification. Public v0.4.0 remains blocked; the matrix below remains historical.
 
+Candidate.3 source: `bf21c82556fcb06afb967ec09023d47a50aa92c5`, protected CI run
+`33936524743`. Artifact checksums, both Developer ID requirements and CI
+notarization passed. Its truthful degraded status exposed a separate qualification
+budget mismatch: checkpoint recovery made progress, but the 30-second installer
+readiness window expired. The qualification installer restored candidate 2 and
+its exact integrity hash; the parked synthetic event remained unchanged. No
+additional live message was sent on candidate 3. The updater now allows five
+minutes of scheduled readiness checks while still requiring ready and preserving
+rollback. This runtime change requires another immutable signed candidate.
+
 ## Current matrix
 
 | Surface | Qualified version | Evidence | Status |

--- a/docs/UPDATES.md
+++ b/docs/UPDATES.md
@@ -59,6 +59,12 @@ and waits for content-free health. Failure restores the last-known-good binary
 and configuration. The old updater process remains alive during this transaction,
 so it can roll back even when the candidate cannot start.
 
+Readiness qualification allows up to five minutes of scheduled waits, plus the
+time spent in status probes, so bounded checkpoint recovery can finish. Degraded
+or starting status never counts as ready; failure still restores the previous
+binary and configuration. An older updater retains its older startup budget and
+may need an idle retry if a large recovery backlog prevents timely qualification.
+
 The listener's LaunchAgent requests a finite 120-second exit window; launchd may
 apply a shorter effective limit (60 seconds was reported on macOS 26.5.1 during
 candidate-2 qualification). Shutdown

--- a/docs/analysis/2026-09-04-reliability-review.md
+++ b/docs/analysis/2026-09-04-reliability-review.md
@@ -75,3 +75,20 @@ startup marker within 2.5 seconds; the unchanged rerun drained successfully in
 27 seconds. The fixture now allows a bounded 10-second startup wait while keeping
 the same active-child completion and unloaded-service assertions. This changes
 test startup tolerance, not the product's shutdown deadline.
+
+## Startup qualification budget review
+
+Baseline: `bf21c82556fcb06afb967ec09023d47a50aa92c5`. Candidate 3 truthfully
+reported recovery degradation and advanced 7–9 rows per 30-second catch-up
+attempt, but the qualification installer's 30-second readiness window expired
+and rolled back. The public updater had the same 60 x 500 ms budget.
+
+Standards: change only the bounded readiness poll budget to 600 x 500 ms; do not
+accept starting/degraded status, alter identity/signature checks, change provider
+recovery limits or advance release state early. Document probe overhead and that
+an older updater retains its own older budget. No new retry abstraction.
+
+Spec: the existing updater lifecycle fixture failed with 90 delayed health
+checks before the fix and now installs the qualified candidate. The permanently
+unready case still rolls back, now asserting exactly 300,000 ms of scheduled
+waits. Candidate 3's prior live evidence cannot qualify this runtime change.

--- a/packages/cli/src/update.ts
+++ b/packages/cli/src/update.ts
@@ -55,7 +55,8 @@ export const PRONTO_UPDATE_PUBLIC_KEY_SPKI_DER_BASE64 =
 const MAX_ENVELOPE_BYTES = 64 * 1_024;
 const MAX_ARTIFACT_BYTES = 256 * 1_024 * 1_024;
 const UPDATE_TIMEOUT_MS = 30_000;
-const QUALIFICATION_ATTEMPTS = 60;
+// Allow multiple bounded catch-up attempts without accepting degraded as ready.
+const QUALIFICATION_ATTEMPTS = 600;
 const QUALIFICATION_INTERVAL_MS = 500;
 
 export type ProntoUpdateTarget = "darwin-arm64" | "darwin-x64";

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -129,7 +129,7 @@ describe("Pronto update envelope", () => {
 });
 
 describe("Pronto updater", () => {
-  test("stages, verifies, atomically installs, and records a qualified update", async () => {
+  test.each([0, 90])("qualifies an update after bounded checkpoint recovery (%i delayed health checks)", async (delayedHealthChecks) => {
     const home = await mkdtemp(join(tmpdir(), "pronto-update-"));
     temporaryDirectories.push(home);
     const paths = pathsForHome(home);
@@ -149,6 +149,7 @@ describe("Pronto updater", () => {
     const available = manifest(candidate);
     const calls: string[] = [];
     let fetchCount = 0;
+    let healthChecks = 0;
     const updater = new ProntoUpdater(paths, {
       currentVersion: "0.2.4",
       fetch: async () => {
@@ -165,6 +166,9 @@ describe("Pronto updater", () => {
       run: async (executable, args) => {
         if (args[0] === "--version") return { exitCode: 0, stderr: "", stdout: "pronto 0.3.0\n" };
         calls.push(`${executable}:${args.join(" ")}`);
+        if (args[0] === "status" && healthChecks++ < delayedHealthChecks) {
+          return { exitCode: 1, stderr: "", stdout: JSON.stringify({ daemon: "degraded", degradedCapabilities: ["messages-recovery-duration-limit"] }) };
+        }
         return { exitCode: 0, stderr: "", stdout: "{}" };
       },
       stopAgent: async () => { calls.push("stop"); },
@@ -223,6 +227,7 @@ describe("Pronto updater", () => {
     const available = manifest(candidate);
     let fetchCount = 0;
     let mainAgentInstalls = 0;
+    let waitedMs = 0;
     const updater = new ProntoUpdater(paths, {
       currentVersion: "0.2.4",
       fetch: async () => new Response(++fetchCount === 1 ? "manifest" : candidate),
@@ -237,13 +242,14 @@ describe("Pronto updater", () => {
         : { exitCode: 1, stderr: "not ready", stdout: "" },
       stopAgent: async () => undefined,
       verifyEnvelope: () => available,
-      wait: async () => undefined,
+      wait: async (milliseconds) => { waitedMs += milliseconds; },
     });
 
     await expect(updater.install()).rejects.toThrow("update_candidate_qualification_failed");
     expect(await readFile(paths.executablePath, "utf8")).toBe("known good");
     expect((await loadConfig(paths.configPath)).installedExecutableHash).toBe(originalHash);
     expect(mainAgentInstalls).toBe(2);
+    expect(waitedMs).toBe(300_000);
   });
 
   test("migrates an existing ad-hoc install from a separately downloaded signed candidate", async () => {


### PR DESCRIPTION
## Summary

Candidate 3 correctly exposed degraded recovery instead of false readiness. Its checkpoint advanced, but the 30-second qualification window was too short for multiple bounded catch-up attempts and the installer rolled back safely.

Increase the updater's qualification budget from 60 to 600 half-second waits. Starting or degraded status still never qualifies. Signature, identity, generation, recovery and rollback checks are unchanged. Documentation distinguishes scheduled waits from probe overhead and notes that older updater versions retain their own budget.

## Verification

- The existing updater lifecycle fixture failed after 90 delayed health checks before the fix and now installs successfully.
- Permanent non-readiness still rolls back and asserts 300,000 ms of scheduled waits.
- 262 tests pass, one native test skipped by default; typecheck/build/offline release validation pass.
- Separate Standards and Spec review is recorded in the repo.

No publication or live qualification is claimed. The runtime change requires a new immutable signed candidate. No real message content, account identifiers or local configuration is included.
